### PR TITLE
fix(LanguageManager): allow initialisation from config with language ids file

### DIFF
--- a/TTS/tts/utils/languages.py
+++ b/TTS/tts/utils/languages.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import fsspec
 import numpy as np
@@ -85,18 +85,18 @@ class LanguageManager(BaseIDManager):
         self._save_json(file_path, self.name_to_id)
 
     @staticmethod
-    def init_from_config(config: Coqpit) -> "LanguageManager":
+    def init_from_config(config: Coqpit) -> Optional["LanguageManager"]:
         """Initialize the language manager from a Coqpit config.
 
         Args:
             config (Coqpit): Coqpit config.
         """
-        language_manager = None
         if check_config_and_model_args(config, "use_language_embedding", True):
             if config.get("language_ids_file", None):
-                language_manager = LanguageManager(language_ids_file_path=config.language_ids_file)
-            language_manager = LanguageManager(config=config)
-        return language_manager
+                return LanguageManager(language_ids_file_path=config.language_ids_file)
+            # Fall back to parse language IDs from the config
+            return LanguageManager(config=config)
+        return None
 
 
 def _set_file_path(path):


### PR DESCRIPTION
Noticed this when testing the mixed-language TTS:

Previously, running `LanguageManager.init_from_config(config)` would never use the `language_ids_file` if that field is present because it was overwritten in the next line with a new manager that manually parses languages from the datasets in the config. Now that is only used as a fallback.