### PR TITLE
fix(server): ensure logging output gets actually shown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -59,7 +59,7 @@ body:
         You can either run `TTS/bin/collect_env_info.py`
 
         ```bash
-        wget https://raw.githubusercontent.com/coqui-ai/TTS/main/TTS/bin/collect_env_info.py
+        wget https://raw.githubusercontent.com/idiap/coqui-ai-TTS/main/TTS/bin/collect_env_info.py
         python collect_env_info.py
         ```
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: CoquiTTS GitHub Discussions
-    url: https://github.com/coqui-ai/TTS/discussions
+    url: https://github.com/idiap/coqui-ai-TTS/discussions
     about: Please ask and answer questions here.
   - name: Coqui Security issue disclosure
-    url: mailto:info@coqui.ai
+    url: mailto:enno.hermann@gmail.com
     about: Please report security vulnerabilities here.

--- a/.github/PR_TEMPLATE.md
+++ b/.github/PR_TEMPLATE.md
@@ -5,11 +5,3 @@ Welcome to the 🐸TTS project! We are excited to see your interest, and appreci
 This repository is governed by the Contributor Covenant Code of Conduct. For more details, see the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) file.
 
 In order to make a good pull request, please see our [CONTRIBUTING.md](CONTRIBUTING.md) file.
-
-Before accepting your pull request, you will be asked to sign a [Contributor License Agreement](https://cla-assistant.io/coqui-ai/TTS).
-
-This [Contributor License Agreement](https://cla-assistant.io/coqui-ai/TTS):
-
-- Protects you, Coqui, and the users of the code.
-- Does not change your rights to use your contributions for any purpose.
-- Does not change the license of the 🐸TTS project. It just makes the terms of your contribution clearer and lets us know you are OK to contribute.

--- a/TTS/encoder/utils/prepare_voxceleb.py
+++ b/TTS/encoder/utils/prepare_voxceleb.py
@@ -29,6 +29,8 @@ import zipfile
 
 import soundfile as sf
 
+from TTS.utils.generic_utils import ConsoleFormatter, setup_logger
+
 logger = logging.getLogger(__name__)
 
 SUBSETS = {
@@ -214,7 +216,7 @@ def processor(directory, subset, force_process):
 
 
 if __name__ == "__main__":
-    logging.getLogger("TTS").setLevel(logging.INFO)
+    setup_logger("TTS", level=logging.INFO, screen=True, formatter=ConsoleFormatter())
     if len(sys.argv) != 4:
         print("Usage: python prepare_data.py save_directory user password")
         sys.exit()

--- a/TTS/server/server.py
+++ b/TTS/server/server.py
@@ -1,4 +1,7 @@
 #!flask/bin/python
+
+"""TTS demo server."""
+
 import argparse
 import io
 import json
@@ -13,7 +16,8 @@ from urllib.parse import parse_qs
 try:
     from flask import Flask, render_template, render_template_string, request, send_file
 except ImportError as e:
-    raise ImportError("Server requires requires flask, use `pip install coqui-tts[server]`.") from e
+    msg = "Server requires requires flask, use `pip install coqui-tts[server]`"
+    raise ImportError(msg) from e
 
 from TTS.config import load_config
 from TTS.utils.generic_utils import ConsoleFormatter, setup_logger
@@ -24,17 +28,11 @@ logger = logging.getLogger(__name__)
 setup_logger("TTS", level=logging.INFO, screen=True, formatter=ConsoleFormatter())
 
 
-def create_argparser():
-    def convert_boolean(x):
-        return x.lower() in ["true", "1", "yes"]
-
+def create_argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--list_models",
-        type=convert_boolean,
-        nargs="?",
-        const=True,
-        default=False,
+        action="store_true",
         help="list available pre-trained tts and vocoder models.",
     )
     parser.add_argument(
@@ -62,9 +60,13 @@ def create_argparser():
     parser.add_argument("--vocoder_config_path", type=str, help="Path to vocoder model config file.", default=None)
     parser.add_argument("--speakers_file_path", type=str, help="JSON file for multi-speaker model.", default=None)
     parser.add_argument("--port", type=int, default=5002, help="port to listen on.")
-    parser.add_argument("--use_cuda", type=convert_boolean, default=False, help="true to use CUDA.")
-    parser.add_argument("--debug", type=convert_boolean, default=False, help="true to enable Flask debug mode.")
-    parser.add_argument("--show_details", type=convert_boolean, default=False, help="Generate model detail page.")
+    parser.add_argument("--use_cuda", action=argparse.BooleanOptionalAction, default=False, help="true to use CUDA.")
+    parser.add_argument(
+        "--debug", action=argparse.BooleanOptionalAction, default=False, help="true to enable Flask debug mode."
+    )
+    parser.add_argument(
+        "--show_details", action=argparse.BooleanOptionalAction, default=False, help="Generate model detail page."
+    )
     return parser
 
 
@@ -168,17 +170,15 @@ def index():
 def details():
     if args.config_path is not None and os.path.isfile(args.config_path):
         model_config = load_config(args.config_path)
-    else:
-        if args.model_name is not None:
-            model_config = load_config(config_path)
+    elif args.model_name is not None:
+        model_config = load_config(config_path)
 
     if args.vocoder_config_path is not None and os.path.isfile(args.vocoder_config_path):
         vocoder_config = load_config(args.vocoder_config_path)
+    elif args.vocoder_name is not None:
+        vocoder_config = load_config(vocoder_config_path)
     else:
-        if args.vocoder_name is not None:
-            vocoder_config = load_config(vocoder_config_path)
-        else:
-            vocoder_config = None
+        vocoder_config = None
 
     return render_template(
         "details.html",

--- a/TTS/server/server.py
+++ b/TTS/server/server.py
@@ -16,11 +16,12 @@ except ImportError as e:
     raise ImportError("Server requires requires flask, use `pip install coqui-tts[server]`.") from e
 
 from TTS.config import load_config
+from TTS.utils.generic_utils import ConsoleFormatter, setup_logger
 from TTS.utils.manage import ModelManager
 from TTS.utils.synthesizer import Synthesizer
 
 logger = logging.getLogger(__name__)
-logging.getLogger("TTS").setLevel(logging.INFO)
+setup_logger("TTS", level=logging.INFO, screen=True, formatter=ConsoleFormatter())
 
 
 def create_argparser():

--- a/TTS/server/server.py
+++ b/TTS/server/server.py
@@ -74,10 +74,6 @@ args = create_argparser().parse_args()
 path = Path(__file__).parent / "../.models.json"
 manager = ModelManager(path)
 
-if args.list_models:
-    manager.list_models()
-    sys.exit()
-
 # update in-use models to the specified released models.
 model_path = None
 config_path = None


### PR DESCRIPTION
Running the server didn't show any output because `setup_logger()` was not used as in other similar executables. Addresses #24, but does not yet fix the underlying issue there.