### PR TITLE
Fix XTTS streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The following extras allow the installation of optional dependencies:
 |------|-------------|
 | `all` | All optional dependencies, except `dev` and `docs` |
 | `dev` | Development dependencies |
-| `dev` | Dependencies for building the documentation |
+| `docs` | Dependencies for building the documentation |
 | `notebooks` | Dependencies only used in notebooks |
 | `server` | Dependencies to run the TTS server |
 | `bn` | Bangla G2P |
@@ -270,11 +270,10 @@ You can find the language ISO codes [here](https://dl.fbaipublicfiles.com/mms/tt
 and learn about the Fairseq models [here](https://github.com/facebookresearch/fairseq/tree/main/examples/mms).
 
 ```python
-# TTS with on the fly voice conversion
+# TTS with fairseq models
 api = TTS("tts_models/deu/fairseq/vits")
-api.tts_with_vc_to_file(
+api.tts_to_file(
     "Wie sage ich auf Italienisch, dass ich dich liebe?",
-    speaker_wav="target/speaker.wav",
     file_path="output.wav"
 )
 ```

--- a/TTS/__init__.py
+++ b/TTS/__init__.py
@@ -1,0 +1,3 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version("coqui-tts")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 autodoc_mock_imports = ["soundfile"]
 
 # -- Project information -----------------------------------------------------
-project = "TTS"
+project = "coqui-tts"
 copyright = "2021 Coqui GmbH, 2020 TTS authors"
 author = "Coqui GmbH"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "gruut[de,es,fr]==2.2.3",
     # Tortoise
     "einops>=0.6.0",
-    "transformers>=4.33.0",
+    "transformers>=4.33.0,<4.41.0",
     # Bark
     "encodec>=0.1.1",
     # XTTS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["TTS*"]
 
 [project]
 name = "coqui-tts"
-version = "0.24.0"
+version = "0.24.1"
 description = "Deep learning for Text to Speech."
 readme = "README.md"
 requires-python = ">=3.9, <3.13"


### PR DESCRIPTION
Work around #31 (until XTTS streaming code is updated) by restricting `transformers` to versions below 4.41.0.

Also restore the `TTS.__version__` attribute, which is used by the `TTS/bin/collect_env_info.py` script with which users print
version information for bug reports, so that old versions of the script still work.