### PR TITLE
Fix Espeak issues on Windows

### DIFF
--- a/TTS/tts/utils/text/phonemizers/espeak_wrapper.py
+++ b/TTS/tts/utils/text/phonemizers/espeak_wrapper.py
@@ -50,7 +50,7 @@ else:
     _DEF_ESPEAK_VER = None
 
 
-def _espeak_exe(espeak_lib: str, args: list, *, sync: bool = False) -> list[bytes]:
+def _espeak_exe(espeak_lib: str, args: list) -> list[bytes]:
     """Run espeak with the given arguments."""
     cmd = [
         espeak_lib,
@@ -70,13 +70,6 @@ def _espeak_exe(espeak_lib: str, args: list, *, sync: bool = False) -> list[byte
         err = iter(p.stderr.readline, b"")
         for line in err:
             logger.warning("espeakng: %s", line.decode("utf-8").strip())
-        if not sync:
-            p.stdout.close()
-            if p.stderr:
-                p.stderr.close()
-            if p.stdin:
-                p.stdin.close()
-            return res
         res2 = list(res)
         p.stdout.close()
         if p.stderr:
@@ -201,7 +194,7 @@ class ESpeak(BasePhonemizer):
         args.append(text)
         # compute phonemes
         phonemes = ""
-        for line in _espeak_exe(self.backend, args, sync=True):
+        for line in _espeak_exe(self.backend, args):
             logger.debug("line: %s", repr(line))
             ph_decoded = line.decode("utf8").strip()
             # espeak:
@@ -232,7 +225,7 @@ class ESpeak(BasePhonemizer):
             return {}
         args = ["--voices"]
         langs = {}
-        for count, line in enumerate(_espeak_exe(_DEF_ESPEAK_LIB, args, sync=True)):
+        for count, line in enumerate(_espeak_exe(_DEF_ESPEAK_LIB, args)):
             line = line.decode("utf8").strip()
             if count > 0:
                 cols = line.split()

--- a/TTS/tts/utils/text/phonemizers/espeak_wrapper.py
+++ b/TTS/tts/utils/text/phonemizers/espeak_wrapper.py
@@ -3,6 +3,8 @@
 import logging
 import re
 import subprocess
+import tempfile
+from pathlib import Path
 from typing import Optional
 
 from packaging.version import Version
@@ -184,7 +186,12 @@ class ESpeak(BasePhonemizer):
         if tie:
             args.append("--tie=%s" % tie)
 
-        args.append(text)
+        tmp = tempfile.NamedTemporaryFile(mode="w+t", delete=False, encoding="utf8")
+        tmp.write(text)
+        tmp.close()
+        args.append("-f")
+        args.append(tmp.name)
+
         # compute phonemes
         phonemes = ""
         for line in _espeak_exe(self.backend, args):
@@ -200,6 +207,7 @@ class ESpeak(BasePhonemizer):
             ph_decoded = re.sub(r"\(.+?\)", "", line)
 
             phonemes += ph_decoded.strip()
+        Path(tmp.name).unlink()
         return phonemes.replace("_", separator)
 
     def _phonemize(self, text: str, separator: str = "") -> str:

--- a/tests/text_tests/test_phonemizer.py
+++ b/tests/text_tests/test_phonemizer.py
@@ -116,6 +116,12 @@ class TestEspeakNgPhonemizer(unittest.TestCase):
         output = self.phonemizer.phonemize(text, separator="")
         self.assertEqual(output, gt)
 
+        # UTF8 characters
+        text = "źrebię"
+        gt = "ʑrˈɛbjɛ"
+        output = ESpeak("pl").phonemize(text, separator="")
+        self.assertEqual(output, gt)
+
     def test_name(self):
         self.assertEqual(self.phonemizer.name(), "espeak")
 


### PR DESCRIPTION
- Fixes #24 by updating the Espeak wrapper code to much simpler `subprocess.run` interface
- Fixes https://github.com/coqui-ai/TTS/discussions/3761 by letting `Espeak.phonemize()` read input from a file to avoid character encoding issues in shell arguments