### PR TITLE
build: add numpy2 support

### DIFF
--- a/TTS/vc/models/freevc.py
+++ b/TTS/vc/models/freevc.py
@@ -382,8 +382,7 @@ class FreeVC(BaseVC):
         """Load pretrained speaker encoder model as mentioned in the paper."""
         logger.info("Loading pretrained speaker encoder model ...")
         self.enc_spk_ex = SpeakerEncoderEx(
-            "https://github.com/coqui-ai/TTS/releases/download/v0.13.0_models/speaker_encoder.pt",
-            device=self.device
+            "https://github.com/coqui-ai/TTS/releases/download/v0.13.0_models/speaker_encoder.pt", device=self.device
         )
 
     def init_multispeaker(self, config: Coqpit):

--- a/TTS/vocoder/models/wavernn.py
+++ b/TTS/vocoder/models/wavernn.py
@@ -91,7 +91,7 @@ class UpsampleNetwork(nn.Module):
         use_aux_net,
     ):
         super().__init__()
-        self.total_scale = np.cumproduct(upsample_scales)[-1]
+        self.total_scale = np.cumprod(upsample_scales)[-1]
         self.indent = pad * self.total_scale
         self.use_aux_net = use_aux_net
         if use_aux_net:
@@ -239,7 +239,7 @@ class Wavernn(BaseVocoder):
 
         if self.args.use_upsample_net:
             assert (
-                np.cumproduct(self.args.upsample_factors)[-1] == config.audio.hop_length
+                np.cumprod(self.args.upsample_factors)[-1] == config.audio.hop_length
             ), " [!] upsample scales needs to be equal to hop_length"
             self.upsample = UpsampleNetwork(
                 self.args.feat_dims,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools",
     "cython~=0.29.30",
-    "numpy>=1.24.3",
+    "numpy>=2.0.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -84,7 +84,7 @@ dev = [
     "coverage[toml]",
     "nose2",
     "pre-commit",
-    "ruff==0.3.0",
+    "ruff==0.4.9",
     "tomli; python_version < '3.11'",
 ]
 # Dependencies for building the documentation
@@ -169,6 +169,7 @@ lint.extend-select = [
     "PLR1711", # useless-return
     "PLW",
     "W291", # trailing-whitespace
+    "NPY201",  # NumPy 2.0 deprecation
 ]
 
 lint.ignore = [

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,5 +4,5 @@ black==24.2.0
 coverage[toml]
 nose2
 pre-commit
-ruff==0.3.0
+ruff==0.4.9
 tomli; python_version < '3.11'


### PR DESCRIPTION
Identified (just 2) necessary code changes with the NPY201 ruff rule.

Gruut is the only dependency that doesn't support numpy2 yet, so it won't work right away.

NB: At build time numpy>=2.0.0 should be required to be able to build wheels compatible with both numpy1+2:
https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-abi-handling