### PR TITLE
Numpy 2 support (gruut, soxr, spacy)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "coqui-tts-trainer>=0.1.4",
     "coqpit>=0.0.16",
     # Gruut + supported languages
-    "gruut[de,es,fr]==2.2.3",
+    "gruut[de,es,fr]>=2.4.0",
     # Tortoise
     "einops>=0.6.0",
     "transformers>=4.42.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "gruut[de,es,fr]>=2.4.0",
     # Tortoise
     "einops>=0.6.0",
-    "transformers>=4.42.0",
+    "transformers>=4.42.0,<4.43.0",
     # Bark
     "encodec>=0.1.1",
     # XTTS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 dependencies = [
     # Core
-    "numpy>=1.24.3",
+    "numpy>=1.24.3,<2.0.0",  # TODO: remove upper bound after spacy/thinc release
     "cython>=0.29.30",
     "scipy>=1.11.2",
     "torch>=2.1",


### PR DESCRIPTION
- Update `gruut` to version 2.4.0 with Numpy 2 and networkx 3 (fixing #55, fixing #68) support.
- ~~[librosa](https://github.com/librosa/librosa/issues/1831)/[soxr](https://github.com/dofuuz/python-soxr/issues/28) are still in the process of being updated, but the soxr 0.4.0b1 prerelease works.~~ Edit: works fine now with soxr 0.4.0
- [spacy](https://github.com/explosion/spaCy/issues/13528)/[thinc](https://github.com/explosion/thinc/issues/939) are not built with Numpy 2 support yet, so add back an upper bound.
- Limit `transformers` to versions 4.42.* as temporary workaround for #65