### PR TITLE
Fix crash when using continue_path in train_gpt_xtts.py

### DIFF
--- a/TTS/tts/models/xtts.py
+++ b/TTS/tts/models/xtts.py
@@ -123,6 +123,7 @@ class XttsAudioConfig(Coqpit):
 
     sample_rate: int = 22050
     output_sample_rate: int = 24000
+    dvae_sample_rate: int = 22050
 
 
 @dataclass
@@ -191,6 +192,18 @@ class XttsArgs(Coqpit):
     # constants
     duration_const: int = 102400
 
+    # training params
+    min_conditioning_length: int = 66150
+    max_conditioning_length: int = 132300
+    gpt_loss_text_ce_weight: float = 0.01
+    gpt_loss_mel_ce_weight: float = 1.0
+    debug_loading_failures: bool = False
+    max_wav_length: int = 255995
+    max_text_length: int = 200
+    mel_norm_file: str = ""
+    dvae_checkpoint: str = ""
+    xtts_checkpoint: str = ""
+    vocoder: str = ""
 
 class Xtts(BaseTTS):
     """ⓍTTS model implementation.

--- a/recipes/ljspeech/xtts_v2/train_gpt_xtts.py
+++ b/recipes/ljspeech/xtts_v2/train_gpt_xtts.py
@@ -156,11 +156,15 @@ def main():
     )
 
     # init the trainer and 🚀
+    continue_path = None # path to the checkpoint that you want to continue training
+    restore_path = None
+    
     trainer = Trainer(
         TrainerArgs(
-            restore_path=None,  # xtts checkpoint is restored via xtts_checkpoint key so no need of restore it using Trainer restore_path parameter
+            continue_path=continue_path,
+            restore_path=restore_path,
             skip_train_epoch=False,
-            start_with_eval=START_WITH_EVAL,
+            start_with_eval=START_WITH_EVAL if continue_path is None and restore_path is None else False,
             grad_accum_steps=GRAD_ACUMM_STEPS,
         ),
         config,


### PR DESCRIPTION
Using continue_path in recipes/ljspeech/xtts_v2/train_gpt_xtts.py causes a crash because the XttsAudioConfig and XttsArgs classes are missing attributes that are saved in the config.json file but are discarded by the loader. This commit addresses the issue by ensuring these attributes are present to prevent crashes.