### PR TITLE
Enable Numpy 2 support after Spacy 3.8 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 dependencies = [
     # Core
-    "numpy>=1.25.2,<2.0.0",  # TODO: remove upper bound after spacy/thinc release
+    "numpy>=1.25.2",
     "cython>=0.29.30",
     "scipy>=1.11.2",
     "torch>=2.4",


### PR DESCRIPTION
It still installs Numpy<2 for now because Spacy although built with Numpy 2 support still depends on an older `thinc` version: https://github.com/explosion/spaCy/issues/13607 Should work automatically in future releases.