### PR TITLE
Integrate pygoruut

### DIFF
--- a/TTS/tts/utils/text/phonemizers/__init__.py
+++ b/TTS/tts/utils/text/phonemizers/__init__.py
@@ -2,6 +2,7 @@ from TTS.tts.utils.text.phonemizers.base import BasePhonemizer
 from TTS.tts.utils.text.phonemizers.belarusian_phonemizer import BEL_Phonemizer
 from TTS.tts.utils.text.phonemizers.espeak_wrapper import ESpeak
 from TTS.tts.utils.text.phonemizers.gruut_wrapper import Gruut
+from TTS.tts.utils.text.phonemizers.pygoruut_wrapper import Pygoruut
 
 try:
     from TTS.tts.utils.text.phonemizers.bangla_phonemizer import BN_Phonemizer
@@ -23,11 +24,12 @@ try:
 except ImportError:
     ZH_CN_Phonemizer = None
 
-PHONEMIZERS = {b.name(): b for b in (ESpeak, Gruut)}
+PHONEMIZERS = {b.name(): b for b in (ESpeak, Gruut, Pygoruut)}
 
 
 ESPEAK_LANGS = list(ESpeak.supported_languages().keys())
 GRUUT_LANGS = list(Gruut.supported_languages())
+PYGORUUT_LANGS = list(Pygoruut.supported_languages())
 
 
 # Dict setting default phonemizers for each language
@@ -35,6 +37,10 @@ GRUUT_LANGS = list(Gruut.supported_languages())
 _ = [Gruut.name()] * len(GRUUT_LANGS)
 DEF_LANG_TO_PHONEMIZER = dict(list(zip(GRUUT_LANGS, _)))
 
+# Add Pygoruut languages and override any existing ones
+_ = [Pygoruut.name()] * len(PYGORUUT_LANGS)
+_new_dict = dict(list(zip(list(PYGORUUT_LANGS), _)))
+DEF_LANG_TO_PHONEMIZER.update(_new_dict)
 
 # Add ESpeak languages and override any existing ones
 _ = [ESpeak.name()] * len(ESPEAK_LANGS)
@@ -75,6 +81,8 @@ def get_phonemizer_by_name(name: str, **kwargs) -> BasePhonemizer:
         return ESpeak(**kwargs)
     if name == "gruut":
         return Gruut(**kwargs)
+    if name == "pygoruut":
+        return Pygoruut(**kwargs)
     if name == "zh_cn_phonemizer":
         if ZH_CN_Phonemizer is None:
             raise ValueError("You need to install ZH phonemizer dependencies. Try `pip install coqui-tts[zh]`.")

--- a/TTS/tts/utils/text/phonemizers/pygoruut_wrapper.py
+++ b/TTS/tts/utils/text/phonemizers/pygoruut_wrapper.py
@@ -1,0 +1,137 @@
+import importlib
+from typing import List
+
+import pygoruut.pygoruut
+from pygoruut.pygoruut import Pygoruut, PygoruutLanguages
+
+from TTS.tts.utils.text.phonemizers.base import BasePhonemizer
+from TTS.tts.utils.text.punctuation import Punctuation
+
+# Table for str.translate to fix goruut/TTS phoneme mismatch
+PYGORUUT_TRANS_TABLE = str.maketrans("g", "ɡ")
+
+
+class Pygoruut(BasePhonemizer):
+    """Pygoruut (goruut) wrapper for G2P
+
+    Args:
+        language (str):
+            Valid language code for the used backend.
+
+        version (str):
+            Version of the backend to initialize. Defaults to the latest version.
+
+        punctuations (str):
+            Unused.
+
+        keep_puncs (bool):
+            Unsupported.
+
+        use_espeak_phonemes (bool):
+            Currently unsupported.
+
+        keep_stress (bool):
+            Unsupported. Currently there is no stress.
+
+    Example:
+
+        >>> from TTS.tts.utils.text.phonemizers.pygoruut_wrapper import Pygoruut
+        >>> phonemizer = Pygoruut('en')
+        >>> phonemizer.phonemize("Be a voice, not an! echo?", separator="|")
+        'b| æ| voʊɪs| noʊt| æ| ɛtʃoʊ'
+    """
+
+    def __init__(
+        self,
+        language: str,
+        version: str = None,
+        punctuations=None,
+        keep_puncs=True,
+        use_espeak_phonemes=False,
+        keep_stress=False,
+    ):
+        super().__init__(language=language)
+        if punctuations is None:
+            self.punctuations = "\x00"
+        else:
+            self.punctuations = punctuations
+        self.pygoruut = pygoruut.pygoruut.Pygoruut(version=version)
+
+    @staticmethod
+    def name():
+        return "pygoruut"
+
+    def phonemize_goruut(self, text: str, separator: str = "|", tie=False, language=None) -> str:  # pylint: disable=unused-argument
+        """Convert input text to phonemes.
+
+        Goruut phonemizes the given `str` by seperating each phonetic word with `separator`.
+
+        It doesn't affect 🐸TTS since it individually converts each character to token IDs and individual phones aren't needed.
+
+        Examples::
+            "hello how are you today?" -> `hɛloʊ| hoʊ| ɚi| iaʊ| toʊdeɪ`
+
+        Args:
+            text (str):
+                Text to be converted to phonemes.
+
+            tie (bool, optional) : Unsupported. Default to False.
+        """
+        if language is None:
+            language = self.language
+        resp = self.pygoruut.phonemize(language=language, sentence=text)
+        ph_words = []
+        for word in resp.Words:
+            word_phonemes = word.Phonetic.translate(PYGORUUT_TRANS_TABLE)
+            ph_words.append(word_phonemes)
+
+        ph = f"{separator} ".join(ph_words)
+        return ph
+
+    def _phonemize(self, text, separator, language=None):
+        return self.phonemize_goruut(text, separator, tie=False, language=language)
+
+    def is_supported_language(self, language=None):
+        """Returns True if `language` is supported by the backend"""
+        if language is None:
+            language = self.language
+        ret = language in PygoruutLanguages().get_all_supported_languages()
+        #print(language, ret)
+        return ret
+
+    @staticmethod
+    def supported_languages() -> List:
+        """Get a dictionary of supported languages.
+
+        Returns:
+            List: List of language codes.
+        """
+        return PygoruutLanguages().get_supported_languages()
+
+    def version(self):
+        """Get the version of the used backend.
+
+        Returns:
+            str: Version of the used backend.
+        """
+        return self.pygoruut.exact_version()
+
+    @classmethod
+    def is_available(cls):
+        """Return true"""
+        return True
+
+
+if __name__ == "__main__":
+    e = Pygoruut(language="en")
+    print(e.supported_languages())
+    print(e.version())
+    print(e.language)
+    print(e.name())
+    print(e.is_available())
+
+    e = Pygoruut(language="en", keep_puncs=False)
+    print("`" + e.phonemize("hello how are you today?") + "`")
+
+    e = Pygoruut(language="en", keep_puncs=True)
+    print("`" + e.phonemize("hello how, are you today?") + "`")

--- a/TTS/tts/utils/text/phonemizers/pygoruut_wrapper.py
+++ b/TTS/tts/utils/text/phonemizers/pygoruut_wrapper.py
@@ -7,10 +7,6 @@ from pygoruut.pygoruut import Pygoruut, PygoruutLanguages
 from TTS.tts.utils.text.phonemizers.base import BasePhonemizer
 from TTS.tts.utils.text.punctuation import Punctuation
 
-# Table for str.translate to fix goruut/TTS phoneme mismatch
-PYGORUUT_TRANS_TABLE = str.maketrans("g", "ɡ")
-
-
 class Pygoruut(BasePhonemizer):
     """Pygoruut (goruut) wrapper for G2P
 
@@ -64,7 +60,7 @@ class Pygoruut(BasePhonemizer):
     def phonemize_goruut(self, text: str, separator: str = "|", tie=False, language=None) -> str:  # pylint: disable=unused-argument
         """Convert input text to phonemes.
 
-        Goruut phonemizes the given `str` by seperating each phonetic word with `separator`.
+        Gruut phonemizes the given `str` by seperating each phonetic word with `separator`.
 
         It doesn't affect 🐸TTS since it individually converts each character to token IDs and individual phones aren't needed.
 
@@ -82,8 +78,7 @@ class Pygoruut(BasePhonemizer):
         resp = self.pygoruut.phonemize(language=language, sentence=text)
         ph_words = []
         for word in resp.Words:
-            word_phonemes = word.Phonetic.translate(PYGORUUT_TRANS_TABLE)
-            ph_words.append(word_phonemes)
+            ph_words.append(word.Phonetic)
 
         ph = f"{separator} ".join(ph_words)
         return ph

--- a/TTS/tts/utils/text/phonemizers/pygoruut_wrapper.py
+++ b/TTS/tts/utils/text/phonemizers/pygoruut_wrapper.py
@@ -34,7 +34,7 @@ class Pygoruut(BasePhonemizer):
         >>> from TTS.tts.utils.text.phonemizers.pygoruut_wrapper import Pygoruut
         >>> phonemizer = Pygoruut('en')
         >>> phonemizer.phonemize("Be a voice, not an! echo?", separator="|")
-        'b| æ| voʊɪs| noʊt| æ| ɛtʃoʊ'
+        'bə| ə| voʊikɪ| noʊt| ən| ɪtʃoʊ'
     """
 
     def __init__(
@@ -60,12 +60,12 @@ class Pygoruut(BasePhonemizer):
     def phonemize_goruut(self, text: str, separator: str = "|", tie=False, language=None) -> str:  # pylint: disable=unused-argument
         """Convert input text to phonemes.
 
-        Gruut phonemizes the given `str` by seperating each phonetic word with `separator`.
+        Goruut phonemizes the given `str` by seperating each phonetic word with `separator`.
 
         It doesn't affect 🐸TTS since it individually converts each character to token IDs and individual phones aren't needed.
 
         Examples::
-            "hello how are you today?" -> `hɛloʊ| hoʊ| ɚi| iaʊ| toʊdeɪ`
+            "hello how are you today?" -> `hˈɛlloʊ| hoʊw| əɹˈɛ| iˈaʊ| toʊdˈæi`
 
         Args:
             text (str):

--- a/TTS/tts/utils/text/phonemizers/pygoruut_wrapper.py
+++ b/TTS/tts/utils/text/phonemizers/pygoruut_wrapper.py
@@ -27,7 +27,7 @@ class Pygoruut(BasePhonemizer):
             Currently unsupported.
 
         keep_stress (bool):
-            Unsupported. Currently there is no stress.
+            Unsupported. Currently there is stress.
 
     Example:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ dependencies = [
     "coqpit>=0.0.16",
     # Gruut + supported languages
     "gruut[de,es,fr]>=2.4.0",
+    # PyGoruut
+    "pygoruut>=0.0.6",
     # Tortoise
     "einops>=0.6.0",
     "transformers>=4.42.0,<4.43.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     # Gruut + supported languages
     "gruut[de,es,fr]>=2.4.0",
     # PyGoruut
-    "pygoruut>=0.0.6",
+    "pygoruut>=0.1.0",
     # Tortoise
     "einops>=0.6.0",
     "transformers>=4.42.0,<4.43.0",


### PR DESCRIPTION
# Add pygoruut

For a complete implementation, it would be needed to store the pygoruut backend version into the trained model.
At inference time, the pygoruut backend version would be loaded, allowing us to load exactly the same pygoruut,
inferring the language words identically like at the model training startup time.

A more involved refactor of coqui internals would be likely needed to achieve this.