### PR TITLE
build: restrict numpy<2 to avoid build errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools",
     "setuptools-scm",
-    "cython~=0.29.30",
+    "cython",
     "numpy>=2.0.0",
 ]
 build-backend = "setuptools.build_meta"
@@ -44,7 +44,7 @@ classifiers = [
 ]
 dependencies = [
     # Core
-    "numpy>=1.25.2",
+    "numpy>=1.25.2,<2",
     "cython>=0.29.30",
     "scipy>=1.11.2",
     "torch>=2.4",


### PR DESCRIPTION
The following error occured during the build:
```
#15 46.12   × Preparing metadata (pyproject.toml) did not run successfully.
#15 46.12   │ exit code: 1
#15 46.12   ╰─> [23 lines of output]
#15 46.12       Partial import of sklearn during the build process.
#15 46.12       Traceback (most recent call last):
#15 46.12         File "/usr/local/lib/python3.10/dist-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
#15 46.12           main()
#15 46.12         File "/usr/local/lib/python3.10/dist-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
#15 46.12           json_out['return_val'] = hook(**hook_input['kwargs'])
#15 46.12         File "/usr/local/lib/python3.10/dist-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
#15 46.12           return hook(metadata_directory, config_settings)
#15 46.12         File "/tmp/pip-build-env-buzqzx8x/overlay/local/lib/python3.10/dist-packages/setuptools/build_meta.py", line 373, in prepare_metadata_for_build_wheel
#15 46.12           self.run_setup()
#15 46.12         File "/tmp/pip-build-env-buzqzx8x/overlay/local/lib/python3.10/dist-packages/setuptools/build_meta.py", line 503, in run_setup
#15 46.12           super().run_setup(setup_script=setup_script)
#15 46.12         File "/tmp/pip-build-env-buzqzx8x/overlay/local/lib/python3.10/dist-packages/setuptools/build_meta.py", line 318, in run_setup
#15 46.12           exec(code, locals())
#15 46.12         File "<string>", line 319, in <module>
#15 46.12         File "<string>", line 311, in setup_package
#15 46.12         File "/tmp/pip-build-env-buzqzx8x/overlay/local/lib/python3.10/dist-packages/numpy/distutils/core.py", line 24, in <module>
#15 46.12           from numpy.distutils.command import config, config_compiler, \
#15 46.12         File "/tmp/pip-build-env-buzqzx8x/overlay/local/lib/python3.10/dist-packages/numpy/distutils/command/config.py", line 19, in <module>
#15 46.12           from numpy.distutils.mingw32ccompiler import generate_manifest
#15 46.12         File "/tmp/pip-build-env-buzqzx8x/overlay/local/lib/python3.10/dist-packages/numpy/distutils/mingw32ccompiler.py", line 29, in <module>
#15 46.12           from distutils.msvccompiler import get_build_version as get_build_msvc_version
#15 46.12       ModuleNotFoundError: No module named 'distutils.msvccompiler'
#15 46.12       [end of output]
```