### PR TITLE
Potential fix for #90, #91

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools<74",
+    "setuptools",
     "setuptools-scm",
     "cython",
     "numpy>=2.0.0",
@@ -44,7 +44,7 @@ classifiers = [
 ]
 dependencies = [
     # Core
-    "numpy>=1.25.2",
+    "numpy>=1.25.2,<2",
     "cython>=0.29.30",
     "scipy>=1.11.2",
     "torch>=2.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "gruut[de,es,fr]>=2.4.0",
     # Tortoise
     "einops>=0.6.0",
-    "transformers>=4.42.0,<4.43.0",
+    "transformers>=4.42.0",
     # Bark
     "encodec>=0.1.1",
     # XTTS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 dependencies = [
     # Core
     "numpy>=1.25.2,<2",
-    "cython>=0.29.30",
+    "cython==3.0.11",         # Added exact version
     "scipy>=1.11.2",
     "torch>=2.4",
     "torchaudio",
@@ -73,7 +73,10 @@ dependencies = [
     "encodec>=0.1.1",
     # XTTS
     "num2words>=0.5.11",
-    "spacy[ja]>=3"
+    "spacy[ja]==3.7.5",         # Added exact version
+    "soxr==0.4.0",              # Added exact version
+    "scikit-learn==1.5.1",      # Added exact version
+    "contourpy==1.2.1",         # Added exact version
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-    "setuptools",
+    "setuptools<74",
     "setuptools-scm",
-    "cython~=0.29.30",
+    "cython",
     "numpy>=2.0.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools",
     "setuptools-scm",
-    "cython",
+    "cython>=3.0.0",
     "numpy>=2.0.0",
 ]
 build-backend = "setuptools.build_meta"
@@ -44,8 +44,8 @@ classifiers = [
 ]
 dependencies = [
     # Core
-    "numpy>=1.25.2,<2",
-    "cython==3.0.11",         # Added exact version
+    "numpy>=1.25.2",
+    "cython>=3.0.0",
     "scipy>=1.11.2",
     "torch>=2.4",
     "torchaudio",
@@ -68,15 +68,12 @@ dependencies = [
     "gruut[de,es,fr]>=2.4.0",
     # Tortoise
     "einops>=0.6.0",
-    "transformers>=4.42.0",
+    "transformers>=4.42.0,<4.43.0",
     # Bark
     "encodec>=0.1.1",
     # XTTS
     "num2words>=0.5.11",
-    "spacy[ja]==3.7.5",         # Added exact version
-    "soxr==0.4.0",              # Added exact version
-    "scikit-learn==1.5.1",      # Added exact version
-    "contourpy==1.2.1",         # Added exact version
+    "spacy[ja]>=3,<3.8",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixing versions of dependencies in the pyproject.toml.

Probably some version restrictions could be lowered.

dependencies = [
#...
"cython==3.0.11", # Added exact version
"spacy[ja]==3.7.5", # Added exact version
"soxr==0.4.0", # Added exact version
"scikit-learn==1.5.1", # Added exact version
"contourpy==1.2.1", # Added exact version
]

Fixes #91