### PR TITLE
ci(release): switch to cibuildwheel

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -8,6 +8,7 @@ defaults:
       bash
 jobs:
   build-sdist:
+    name: Build source distribution
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,37 +24,31 @@ jobs:
         with:
           python-version: 3.9
       - run: |
-          python -m pip install -U pip setuptools wheel build
+          python -m pip install -U pip setuptools build
       - run: |
           python -m build
       - run: |
           pip install dist/*.tar.gz
       - uses: actions/upload-artifact@v4
         with:
-          name: sdist
+          name: build-sdist
           path: dist/*.tar.gz
   build-wheels:
-    runs-on: ubuntu-latest
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install build requirements
-        run: |
-          python -m pip install -U pip setuptools wheel build numpy cython
-      - name: Setup and install manylinux1_x86_64 wheel
-        run: |
-          python setup.py bdist_wheel --plat-name=manylinux1_x86_64
-          python -m pip install dist/*-manylinux*.whl
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.21.1
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.python-version }}
-          path: dist/*-manylinux*.whl
+          name: build-wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
   publish-artifacts:
+    name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [build-sdist, build-wheels]
     environment:
@@ -62,28 +57,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - run: |
-          mkdir dist
       - uses: actions/download-artifact@v4
         with:
-          name: "sdist"
-          path: "dist/"
-      - uses: actions/download-artifact@v4
-        with:
-          name: "wheel-3.9"
-          path: "dist/"
-      - uses: actions/download-artifact@v4
-        with:
-          name: "wheel-3.10"
-          path: "dist/"
-      - uses: actions/download-artifact@v4
-        with:
-          name: "wheel-3.11"
-          path: "dist/"
-      - uses: actions/download-artifact@v4
-        with:
-          name: "wheel-3.12"
-          path: "dist/"
+          path: dist
+          pattern: build-*
+          merge-multiple: true
       - run: |
           ls -lh dist/
       - name: Publish package distributions to PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,3 +205,7 @@ target-version = ['py39']
 [tool.coverage.run]
 parallel = true
 source = ["TTS"]
+
+[tool.cibuildwheel]
+build = "cp*"
+skip = "*-win32 *i686 *musllinux*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ include = ["TTS*"]
 
 [project]
 name = "coqui-tts"
-version = "0.24.1"
+version = "0.24.2"
 description = "Deep learning for Text to Speech."
 readme = "README.md"
 requires-python = ">=3.9, <3.13"


### PR DESCRIPTION
[cibuildwheel](https://github.com/pypa/cibuildwheel) allows building wheels for different platforms, so that we can now also provide Mac and Windows wheels.