### PR TITLE
Update autoregressive.py to avoid warning when pad token is same as eos token

### DIFF
--- a/TTS/tts/layers/tortoise/autoregressive.py
+++ b/TTS/tts/layers/tortoise/autoregressive.py
@@ -600,7 +600,7 @@ class UnifiedVoice(nn.Module):
             inputs,
             bos_token_id=self.start_mel_token,
             pad_token_id=self.stop_mel_token,
-            eos_token_id=self.stop_mel_token,
+            eos_token_id=self.stop_mel_token+1,
             max_length=max_length,
             logits_processor=logits_processor,
             num_return_sequences=num_return_sequences,


### PR DESCRIPTION
Current Tortoise implementation always generates this error:
```
The attention mask is not set and cannot be inferred from input because pad token is same as eos token.As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.
```
This patch sets `pad_token_id` to a different value from `eos_token_id` in `inference_speech` to avoid this unnecessary warning.