### PR TITLE
Add compatibility with transformers>=4.43

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 dependencies = [
     # Core
-    "numpy>=1.25.2",
+    "numpy>=1.25.2,<2.0",
     "cython>=3.0.0",
     "scipy>=1.11.2",
     "torch>=2.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,9 @@ Discussions = "https://github.com/idiap/coqui-ai-TTS/discussions"
 tts = "TTS.bin.synthesize:main"
 tts-server = "TTS.server.server:main"
 
+[tool.uv]
+constraint-dependencies = ["numba>0.58.0"]
+
 [tool.ruff]
 target-version = "py39"
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "gruut[de,es,fr]>=2.4.0",
     # Tortoise
     "einops>=0.6.0",
-    "transformers>=4.42.0,<4.43.0",
+    "transformers>=4.43.0",
     # Bark
     "encodec>=0.1.1",
     # XTTS


### PR DESCRIPTION
Copy of #98, authored by @JohnnyStreet (editing not enabled for that PR). I fixed the style check and had to add some constraints so that the dependency resolution with uv works (to avoid https://github.com/astral-sh/uv/issues/6281). I checked locally that the streaming XTTS inference works with transformers 4.43, 4.44 and 4.45.

Fixes #65