### PR TITLE
fix(gpt): set attention mask and address other warnings

### DIFF
--- a/TTS/tts/layers/xtts/gpt_inference.py
+++ b/TTS/tts/layers/xtts/gpt_inference.py
@@ -1,10 +1,12 @@
 import torch
 from torch import nn
-from transformers import GPT2PreTrainedModel
+from transformers import GenerationMixin, GPT2PreTrainedModel
 from transformers.modeling_outputs import CausalLMOutputWithCrossAttentions
 
+from TTS.tts.layers.xtts.stream_generator import StreamGenerationConfig
 
-class GPT2InferenceModel(GPT2PreTrainedModel):
+
+class GPT2InferenceModel(GPT2PreTrainedModel, GenerationMixin):
     """Override GPT2LMHeadModel to allow for prefix conditioning."""
 
     def __init__(self, config, gpt, pos_emb, embeddings, norm, linear, kv_cache):
@@ -15,6 +17,7 @@ class GPT2InferenceModel(GPT2PreTrainedModel):
         self.final_norm = norm
         self.lm_head = nn.Sequential(norm, linear)
         self.kv_cache = kv_cache
+        self.generation_config = StreamGenerationConfig.from_model_config(config) if self.can_generate() else None
 
     def store_prefix_emb(self, prefix_emb):
         self.cached_prefix_emb = prefix_emb

--- a/TTS/tts/models/xtts.py
+++ b/TTS/tts/models/xtts.py
@@ -667,6 +667,7 @@ class Xtts(BaseTTS):
                 repetition_penalty=float(repetition_penalty),
                 output_attentions=False,
                 output_hidden_states=True,
+                return_dict_in_generate=True,
                 **hf_generate_kwargs,
             )
 


### PR DESCRIPTION
Sets the attention mask in Tortoise and XTTS to avoid the following warning: ```The attention mask is not set and cannot be inferred from input because pad token is same as eos token.As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.```

Also address other warnings during XTTS inference to be ready for future changes in the transformers library.

Obsoletes #106