### PR TITLE
fix(text.characters): add nasal diacritic

### DIFF
--- a/TTS/tts/utils/text/characters.py
+++ b/TTS/tts/utils/text/characters.py
@@ -34,8 +34,8 @@ _non_pulmonic_consonants = "ʘɓǀɗǃʄǂɠǁʛ"
 _pulmonic_consonants = "pbtdʈɖcɟkɡqɢʔɴŋɲɳnɱmʙrʀⱱɾɽɸβfvθðszʃʒʂʐçʝxɣχʁħʕhɦɬɮʋɹɻjɰlɭʎʟ"
 _suprasegmentals = "ˈˌːˑ"
 _other_symbols = "ʍwɥʜʢʡɕʑɺɧʲ"
-_diacrilics = "ɚ˞ɫ"
-_phonemes = _vowels + _non_pulmonic_consonants + _pulmonic_consonants + _suprasegmentals + _other_symbols + _diacrilics
+_diacritics = "̃ɚ˞ɫ"
+_phonemes = _vowels + _non_pulmonic_consonants + _pulmonic_consonants + _suprasegmentals + _other_symbols + _diacritics
 
 
 class BaseVocabulary:


### PR DESCRIPTION
Add the nasal diacritic  ` ̃` to the list of IPA characters to be able to distinguish between non-nasal and nasal versions of vowels, e.g. in French models.

Some previous discussion in https://github.com/coqui-ai/TTS/pull/561#discussion_r649203151