### PR TITLE
ci: allow testing out trainer/coqpit branches before release

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,6 +6,16 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      trainer_branch:
+        description: "Branch of Trainer to test"
+        required: false
+        default: "main"
+      coqpit_branch:
+        description: "Branch of Coqpit to test"
+        required: false
+        default: "main"
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -30,6 +40,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends git make gcc
           make system-deps
+      - name: Install custom Trainer and/or Coqpit if requested
+        run: |
+          if [[ -n "${{ github.event.inputs.trainer_branch }}" ]]; then
+            uv add git+https://github.com/idiap/coqui-ai-Trainer --branch ${{ github.event.inputs.trainer_branch }}
+          fi
+          if [[ -n "${{ github.event.inputs.coqpit_branch }}" ]]; then
+            uv add git+https://github.com/idiap/coqui-ai-coqpit --branch ${{ github.event.inputs.coqpit_branch }}
+          fi
       - name: Integration tests
         run: |
           resolution=highest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,16 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      trainer_branch:
+        description: "Branch of Trainer to test"
+        required: false
+        default: "main"
+      coqpit_branch:
+        description: "Branch of Coqpit to test"
+        required: false
+        default: "main"
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -30,6 +40,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends git make gcc
           make system-deps
+      - name: Install custom Trainer and/or Coqpit if requested
+        run: |
+          if [[ -n "${{ github.event.inputs.trainer_branch }}" ]]; then
+            uv add git+https://github.com/idiap/coqui-ai-Trainer --branch ${{ github.event.inputs.trainer_branch }}
+          fi
+          if [[ -n "${{ github.event.inputs.coqpit_branch }}" ]]; then
+            uv add git+https://github.com/idiap/coqui-ai-coqpit --branch ${{ github.event.inputs.coqpit_branch }}
+          fi
       - name: Unit tests
         run: |
           resolution=highest


### PR DESCRIPTION
Previously I had to manually modify the dependencies and make PRs to run the tests of TTS on a custom branch of Trainer or Coqpit before making a new release there. This PR adds a `workflow_dispatch` trigger, so that the tests can be manually launched on a specified branch. By default it keeps installing the released Trainer/Coqpit version.