### PR TITLE
fix(bark): handle broken paths in config

### DIFF
--- a/TTS/tts/layers/bark/load_model.py
+++ b/TTS/tts/layers/bark/load_model.py
@@ -112,7 +112,9 @@ def load_model(ckpt_path, device, config, model_type="text"):
         os.remove(ckpt_path)
     if not os.path.exists(ckpt_path):
         logger.info(f"{model_type} model not found, downloading...")
-        _download(config.REMOTE_MODEL_PATHS[model_type]["path"], ckpt_path, config.CACHE_DIR)
+        # The URL in the config is a 404 and needs to be fixed
+        download_url = config.REMOTE_MODEL_PATHS[model_type]["path"].replace("tree", "resolve")
+        _download(download_url, ckpt_path, config.CACHE_DIR)
 
     checkpoint = torch.load(ckpt_path, map_location=device, weights_only=is_pytorch_at_least_2_4())
     # this is a hack

--- a/TTS/tts/models/bark.py
+++ b/TTS/tts/models/bark.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 import numpy as np
@@ -269,10 +270,12 @@ class Bark(BaseTTS):
         fine_model_path = fine_model_path or os.path.join(checkpoint_dir, "fine_2.pt")
         hubert_tokenizer_path = hubert_tokenizer_path or os.path.join(checkpoint_dir, "tokenizer.pth")
 
+        # The paths in the default config start with /root/.local/share/tts and need to be fixed
         self.config.LOCAL_MODEL_PATHS["text"] = text_model_path
         self.config.LOCAL_MODEL_PATHS["coarse"] = coarse_model_path
         self.config.LOCAL_MODEL_PATHS["fine"] = fine_model_path
         self.config.LOCAL_MODEL_PATHS["hubert_tokenizer"] = hubert_tokenizer_path
+        self.config.CACHE_DIR = str(Path(text_model_path).parent)
 
         self.load_bark_models()
 


### PR DESCRIPTION
The config for Bark that Coqui downloads from https://huggingface.co/erogol/bark/tree/main contains some incorrect links/paths that can lead to errors in case of failed downloads. This patches up these links accordingly.

Fixes https://github.com/coqui-ai/TTS/issues/2781
Fixes https://github.com/coqui-ai/TTS/issues/3064
Fixes https://github.com/coqui-ai/TTS/issues/3608
Fixes https://github.com/coqui-ai/TTS/issues/3804
Fixes https://github.com/coqui-ai/TTS/issues/4116
Fixes https://github.com/coqui-ai/TTS/issues/4065