### PR TITLE
Add kNN-VC

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ repository are also still a useful source of information.
 
 ### Voice Conversion
 - [FreeVC](https://arxiv.org/abs/2210.15418)
+- [kNN-VC](https://doi.org/10.21437/Interspeech.2023-419)
 - [OpenVoice](https://arxiv.org/abs/2312.01479)
 
 ### Others

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ tts.tts_to_file(text="Ich bin eine Testnachricht.", file_path=OUTPUT_PATH)
 
 #### Voice conversion (VC)
 
-Converting the voice in `source_wav` to the voice of `target_wav`
+Converting the voice in `source_wav` to the voice of `target_wav`:
 
 ```python
 tts = TTS("voice_conversion_models/multilingual/vctk/freevc24").to("cuda")
@@ -247,8 +247,12 @@ tts.voice_conversion_to_file(
 ```
 
 Other available voice conversion models:
+- `voice_conversion_models/multilingual/multi-dataset/knnvc`
 - `voice_conversion_models/multilingual/multi-dataset/openvoice_v1`
 - `voice_conversion_models/multilingual/multi-dataset/openvoice_v2`
+
+For more details, see the
+[documentation](https://coqui-tts.readthedocs.io/en/latest/vc.html).
 
 #### Voice cloning by combining single speaker TTS model with the default VC model
 

--- a/TTS/.models.json
+++ b/TTS/.models.json
@@ -787,6 +787,22 @@
                     "license": "apache 2.0"
                 }
             },
+            "librispeech100": {
+                "wavlm-hifigan": {
+                    "description": "HiFiGAN vocoder for WavLM features from kNN-VC",
+                    "github_rls_url": "https://github.com/idiap/coqui-ai-TTS/releases/download/v0.25.2_models/vocoder_models--en--librispeech100--wavlm-hifigan.zip",
+                    "commit": "cfba7e0",
+                    "author": "Benjamin van Niekerk @bshall, Matthew Baas @RF5",
+                    "license": "MIT"
+                },
+                "wavlm-hifigan_prematched": {
+                    "description": "Prematched HiFiGAN vocoder for WavLM features from kNN-VC",
+                    "github_rls_url": "https://github.com/idiap/coqui-ai-TTS/releases/download/v0.25.2_models/vocoder_models--en--librispeech100--wavlm-hifigan_prematched.zip",
+                    "commit": "cfba7e0",
+                    "author": "Benjamin van Niekerk @bshall, Matthew Baas @RF5",
+                    "license": "MIT"
+                }
+            },
             "ljspeech": {
                 "multiband-melgan": {
                     "github_rls_url": "https://github.com/coqui-ai/TTS/releases/download/v0.6.1_models/vocoder_models--en--ljspeech--multiband-melgan.zip",
@@ -927,18 +943,27 @@
                 "freevc24": {
                     "github_rls_url": "https://github.com/coqui-ai/TTS/releases/download/v0.13.0_models/voice_conversion_models--multilingual--vctk--freevc24.zip",
                     "description": "FreeVC model trained on VCTK dataset from https://github.com/OlaWod/FreeVC",
+                    "default_vocoder": null,
                     "author": "Jing-Yi Li @OlaWod",
                     "license": "MIT",
                     "commit": null
                 }
             },
             "multi-dataset": {
+                "knnvc": {
+                    "description": "kNN-VC model from https://github.com/bshall/knn-vc",
+                    "default_vocoder": "vocoder_models/en/librispeech100/wavlm-hifigan_prematched",
+                    "author": "Benjamin van Niekerk @bshall, Matthew Baas @RF5",
+                    "license": "MIT",
+                    "commit": null
+                },
                 "openvoice_v1": {
                     "hf_url": [
                         "https://huggingface.co/myshell-ai/OpenVoice/resolve/main/checkpoints/converter/config.json",
                         "https://huggingface.co/myshell-ai/OpenVoice/resolve/main/checkpoints/converter/checkpoint.pth"
                     ],
                     "description": "OpenVoice VC model from https://huggingface.co/myshell-ai/OpenVoiceV2",
+                    "default_vocoder": null,
                     "author": "MyShell.ai",
                     "license": "MIT",
                     "commit": null
@@ -949,6 +974,7 @@
                         "https://huggingface.co/myshell-ai/OpenVoiceV2/resolve/main/converter/checkpoint.pth"
                     ],
                     "description": "OpenVoice VC model from https://huggingface.co/myshell-ai/OpenVoiceV2",
+                    "default_vocoder": null,
                     "author": "MyShell.ai",
                     "license": "MIT",
                     "commit": null

--- a/TTS/api.py
+++ b/TTS/api.py
@@ -4,7 +4,7 @@ import logging
 import tempfile
 import warnings
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 from torch import nn
 
@@ -388,7 +388,7 @@ class TTS(nn.Module):
     def voice_conversion(
         self,
         source_wav: str,
-        target_wav: str,
+        target_wav: Union[str, list[str]],
     ):
         """Voice conversion with FreeVC. Convert source wav to target speaker.
 
@@ -406,7 +406,7 @@ class TTS(nn.Module):
     def voice_conversion_to_file(
         self,
         source_wav: str,
-        target_wav: str,
+        target_wav: Union[str, list[str]],
         file_path: str = "output.wav",
         pipe_out=None,
     ) -> str:
@@ -429,8 +429,9 @@ class TTS(nn.Module):
     def tts_with_vc(
         self,
         text: str,
+        *,
         language: Optional[str] = None,
-        speaker_wav: Optional[str] = None,
+        speaker_wav: Union[str, list[str]],
         speaker: Optional[str] = None,
         split_sentences: bool = True,
     ):
@@ -471,8 +472,9 @@ class TTS(nn.Module):
     def tts_with_vc_to_file(
         self,
         text: str,
+        *,
         language: Optional[str] = None,
-        speaker_wav: Optional[str] = None,
+        speaker_wav: Union[str, list[str]],
         file_path: str = "output.wav",
         speaker: Optional[str] = None,
         split_sentences: bool = True,

--- a/TTS/api.py
+++ b/TTS/api.py
@@ -95,7 +95,7 @@ class TTS(nn.Module):
             if "tts_models" in model_name:
                 self.load_tts_model_by_name(model_name, vocoder_name, gpu=gpu)
             elif "voice_conversion_models" in model_name:
-                self.load_vc_model_by_name(model_name, gpu=gpu)
+                self.load_vc_model_by_name(model_name, vocoder_name, gpu=gpu)
             # To allow just TTS("xtts")
             else:
                 self.load_model_by_name(model_name, vocoder_name, gpu=gpu)
@@ -157,22 +157,24 @@ class TTS(nn.Module):
 
     def download_model_by_name(
         self, model_name: str, vocoder_name: Optional[str] = None
-    ) -> tuple[Optional[Path], Optional[Path], Optional[Path]]:
+    ) -> tuple[Optional[Path], Optional[Path], Optional[Path], Optional[Path], Optional[Path]]:
         model_path, config_path, model_item = self.manager.download_model(model_name)
         if "fairseq" in model_name or (model_item is not None and isinstance(model_item["model_url"], list)):
             # return model directory if there are multiple files
             # we assume that the model knows how to load itself
-            return None, None, model_path
+            return None, None, None, None, model_path
         if model_item.get("default_vocoder") is None:
-            return model_path, config_path, None
+            return model_path, config_path, None, None, None
         if vocoder_name is None:
             vocoder_name = model_item["default_vocoder"]
-        vocoder_path, vocoder_config_path, _ = self.manager.download_model(vocoder_name)
-        # A local vocoder model will take precedence if specified via vocoder_path
-        if self.vocoder_path is None or self.vocoder_config_path is None:
-            self.vocoder_path = vocoder_path
-            self.vocoder_config_path = vocoder_config_path
-        return model_path, config_path, None
+        vocoder_path, vocoder_config_path = None, None
+        # A local vocoder model will take precedence if already specified in __init__
+        if model_item["model_type"] == "tts_models":
+            vocoder_path = self.vocoder_path
+            vocoder_config_path = self.vocoder_config_path
+        if vocoder_path is None or vocoder_config_path is None:
+            vocoder_path, vocoder_config_path, _ = self.manager.download_model(vocoder_name)
+        return model_path, config_path, vocoder_path, vocoder_config_path, None
 
     def load_model_by_name(self, model_name: str, vocoder_name: Optional[str] = None, *, gpu: bool = False) -> None:
         """Load one of the 🐸TTS models by name.
@@ -183,7 +185,7 @@ class TTS(nn.Module):
         """
         self.load_tts_model_by_name(model_name, vocoder_name, gpu=gpu)
 
-    def load_vc_model_by_name(self, model_name: str, *, gpu: bool = False) -> None:
+    def load_vc_model_by_name(self, model_name: str, vocoder_name: Optional[str] = None, *, gpu: bool = False) -> None:
         """Load one of the voice conversion models by name.
 
         Args:
@@ -191,9 +193,16 @@ class TTS(nn.Module):
             gpu (bool, optional): Enable/disable GPU. Some models might be too slow on CPU. Defaults to False.
         """
         self.model_name = model_name
-        model_path, config_path, model_dir = self.download_model_by_name(model_name)
+        model_path, config_path, vocoder_path, vocoder_config_path, model_dir = self.download_model_by_name(
+            model_name, vocoder_name
+        )
         self.voice_converter = Synthesizer(
-            vc_checkpoint=model_path, vc_config=config_path, model_dir=model_dir, use_cuda=gpu
+            vc_checkpoint=model_path,
+            vc_config=config_path,
+            vocoder_checkpoint=vocoder_path,
+            vocoder_config=vocoder_config_path,
+            model_dir=model_dir,
+            use_cuda=gpu,
         )
 
     def load_tts_model_by_name(self, model_name: str, vocoder_name: Optional[str] = None, *, gpu: bool = False) -> None:
@@ -208,7 +217,9 @@ class TTS(nn.Module):
         self.synthesizer = None
         self.model_name = model_name
 
-        model_path, config_path, model_dir = self.download_model_by_name(model_name, vocoder_name)
+        model_path, config_path, vocoder_path, vocoder_config_path, model_dir = self.download_model_by_name(
+            model_name, vocoder_name
+        )
 
         # init synthesizer
         # None values are fetch from the model
@@ -217,8 +228,8 @@ class TTS(nn.Module):
             tts_config_path=config_path,
             tts_speakers_file=None,
             tts_languages_file=None,
-            vocoder_checkpoint=self.vocoder_path,
-            vocoder_config=self.vocoder_config_path,
+            vocoder_checkpoint=vocoder_path,
+            vocoder_config=vocoder_config_path,
             encoder_checkpoint=self.encoder_path,
             encoder_config=self.encoder_config_path,
             model_dir=model_dir,

--- a/TTS/api.py
+++ b/TTS/api.py
@@ -77,8 +77,8 @@ class TTS(nn.Module):
         super().__init__()
         self.manager = ModelManager(models_file=self.get_models_file_path(), progress_bar=progress_bar)
         self.config = load_config(config_path) if config_path else None
-        self.synthesizer = None
-        self.voice_converter = None
+        self.synthesizer: Optional[Synthesizer] = None
+        self.voice_converter: Optional[Synthesizer] = None
         self.model_name = ""
 
         self.vocoder_path = vocoder_path

--- a/TTS/bin/synthesize.py
+++ b/TTS/bin/synthesize.py
@@ -275,13 +275,14 @@ def parse_args(arg_list: Optional[list[str]]) -> argparse.Namespace:
         "--source_wav",
         type=str,
         default=None,
-        help="Original audio file to convert in the voice of the target_wav",
+        help="Original audio file to convert into the voice of the target_wav",
     )
     parser.add_argument(
         "--target_wav",
         type=str,
+        nargs="*",
         default=None,
-        help="Target audio file to convert in the voice of the source_wav",
+        help="Audio file(s) of the target voice into which to convert the source_wav",
     )
 
     parser.add_argument(

--- a/TTS/model.py
+++ b/TTS/model.py
@@ -64,3 +64,7 @@ class BaseTrainerModel(TrainerModel):
                 It is cached under `trainer.io.get_user_data_dir()/tts_cache`. Defaults to False.
         """
         ...
+
+    @property
+    def device(self) -> torch.device:
+        return next(self.parameters()).device

--- a/TTS/tts/layers/xtts/trainer/gpt_trainer.py
+++ b/TTS/tts/layers/xtts/trainer/gpt_trainer.py
@@ -197,10 +197,6 @@ class GPTTrainer(BaseTTS):
             mel_norm_file=self.args.mel_norm_file, sampling_rate=config.audio.dvae_sample_rate
         )
 
-    @property
-    def device(self):
-        return next(self.parameters()).device
-
     def forward(self, text_inputs, text_lengths, audio_codes, wav_lengths, cond_mels, cond_idxs, cond_lens):
         """
         Forward pass that uses both text and voice in either text conditioning mode or voice conditioning mode

--- a/TTS/tts/models/bark.py
+++ b/TTS/tts/models/bark.py
@@ -43,10 +43,6 @@ class Bark(BaseTTS):
         self.encodec = EncodecModel.encodec_model_24khz()
         self.encodec.set_target_bandwidth(6.0)
 
-    @property
-    def device(self):
-        return next(self.parameters()).device
-
     def load_bark_models(self):
         self.semantic_model, self.config = load_model(
             ckpt_path=self.config.LOCAL_MODEL_PATHS["text"], device=self.device, config=self.config, model_type="text"

--- a/TTS/tts/models/delightful_tts.py
+++ b/TTS/tts/models/delightful_tts.py
@@ -439,10 +439,6 @@ class DelightfulTTS(BaseTTSE2E):
             )
 
     @property
-    def device(self):
-        return next(self.parameters()).device
-
-    @property
     def energy_scaler(self):
         return self.acoustic_model.energy_scaler
 

--- a/TTS/tts/models/vits.py
+++ b/TTS/tts/models/vits.py
@@ -565,10 +565,6 @@ class Vits(BaseTTS):
                 use_spectral_norm=self.args.use_spectral_norm_disriminator,
             )
 
-    @property
-    def device(self):
-        return next(self.parameters()).device
-
     def init_multispeaker(self, config: Coqpit):
         """Initialize multi-speaker modules of a model. A model can be trained either with a speaker embedding layer
         or with external `d_vectors` computed from a speaker encoder model.

--- a/TTS/tts/models/xtts.py
+++ b/TTS/tts/models/xtts.py
@@ -239,10 +239,6 @@ class Xtts(BaseTTS):
             cond_d_vector_in_each_upsampling_layer=self.args.cond_d_vector_in_each_upsampling_layer,
         )
 
-    @property
-    def device(self):
-        return next(self.parameters()).device
-
     @torch.inference_mode()
     def get_gpt_cond_latents(self, audio, sr, length: int = 30, chunk_length: int = 6):
         """Compute the conditioning latents for the GPT model from the given audio.

--- a/TTS/utils/generic_utils.py
+++ b/TTS/utils/generic_utils.py
@@ -31,6 +31,7 @@ def to_camel(text):
     text = re.sub(r"(?!^)_([a-zA-Z])", lambda m: m.group(1).upper(), text)
     text = text.replace("Tts", "TTS")
     text = text.replace("vc", "VC")
+    text = text.replace("Knn", "KNN")
     return text
 
 

--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -274,8 +274,11 @@ class Synthesizer(nn.Module):
             wav = np.array(wav)
         save_wav(wav=wav, path=path, sample_rate=self.output_sample_rate, pipe_out=pipe_out)
 
-    def voice_conversion(self, source_wav: str, target_wav: str, **kwargs) -> List[int]:
+    def voice_conversion(self, source_wav: str, target_wav: Union[str, list[str]], **kwargs) -> List[int]:
         start_time = time.time()
+
+        if not isinstance(target_wav, list):
+            target_wav = [target_wav]
         output = self.vc_model.voice_conversion(source_wav, target_wav, **kwargs)
         if self.vocoder_model is not None:
             output = self.vocoder_model.inference(output)

--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -274,11 +274,18 @@ class Synthesizer(nn.Module):
             wav = np.array(wav)
         save_wav(wav=wav, path=path, sample_rate=self.output_sample_rate, pipe_out=pipe_out)
 
-    def voice_conversion(self, source_wav: str, target_wav: str) -> List[int]:
-        output = self.vc_model.voice_conversion(source_wav, target_wav)
+    def voice_conversion(self, source_wav: str, target_wav: str, **kwargs) -> List[int]:
+        start_time = time.time()
+        output = self.vc_model.voice_conversion(source_wav, target_wav, **kwargs)
         if self.vocoder_model is not None:
             output = self.vocoder_model.inference(output)
-        return output.squeeze()
+
+        output = output.squeeze()
+        process_time = time.time() - start_time
+        audio_time = len(output) / self.output_sample_rate
+        logger.info("Processing time: %.3f", process_time)
+        logger.info("Real-time factor: %.3f", process_time / audio_time)
+        return output
 
     def tts(
         self,

--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -139,7 +139,9 @@ class Synthesizer(nn.Module):
         """
         # pylint: disable=global-statement
         self.vc_config = load_config(vc_config_path)
-        self.output_sample_rate = self.vc_config.audio["output_sample_rate"]
+        self.output_sample_rate = self.vc_config.audio.get(
+            "output_sample_rate", self.vc_config.audio.get("sample_rate", None)
+        )
         self.vc_model = setup_vc_model(config=self.vc_config)
         self.vc_model.load_checkpoint(self.vc_config, vc_checkpoint)
         if use_cuda:

--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -98,11 +98,11 @@ class Synthesizer(nn.Module):
         if tts_checkpoint:
             self._load_tts(self.tts_checkpoint, self.tts_config_path, use_cuda)
 
-        if vocoder_checkpoint:
-            self._load_vocoder(self.vocoder_checkpoint, self.vocoder_config, use_cuda)
-
         if vc_checkpoint and model_dir == "":
             self._load_vc(self.vc_checkpoint, self.vc_config, use_cuda)
+
+        if vocoder_checkpoint:
+            self._load_vocoder(self.vocoder_checkpoint, self.vocoder_config, use_cuda)
 
         if model_dir:
             if "fairseq" in model_dir:
@@ -275,8 +275,10 @@ class Synthesizer(nn.Module):
         save_wav(wav=wav, path=path, sample_rate=self.output_sample_rate, pipe_out=pipe_out)
 
     def voice_conversion(self, source_wav: str, target_wav: str) -> List[int]:
-        output_wav = self.vc_model.voice_conversion(source_wav, target_wav)
-        return output_wav
+        output = self.vc_model.voice_conversion(source_wav, target_wav)
+        if self.vocoder_model is not None:
+            output = self.vocoder_model.inference(output)
+        return output.squeeze()
 
     def tts(
         self,

--- a/TTS/vc/configs/knnvc_config.py
+++ b/TTS/vc/configs/knnvc_config.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass, field
+
+from coqpit import Coqpit
+
+from TTS.config.shared_configs import BaseAudioConfig
+from TTS.vc.configs.shared_configs import BaseVCConfig
+
+
+@dataclass
+class KNNVCAudioConfig(BaseAudioConfig):
+    """Audio configuration.
+
+    Args:
+        sample_rate (int):
+            The sampling rate of the input waveform.
+    """
+
+    sample_rate: int = field(default=16000)
+
+
+@dataclass
+class KNNVCArgs(Coqpit):
+    """Model arguments.
+
+    Args:
+        ssl_dim (int):
+            The dimension of the self-supervised learning embedding.
+    """
+
+    ssl_dim: int = field(default=1024)
+
+
+@dataclass
+class KNNVCConfig(BaseVCConfig):
+    """Parameters.
+
+    Args:
+        model (str):
+            Model name. Do not change unless you know what you are doing.
+
+        model_args (KNNVCArgs):
+            Model architecture arguments. Defaults to `KNNVCArgs()`.
+
+        audio (KNNVCAudioConfig):
+            Audio processing configuration. Defaults to `KNNVCAudioConfig()`.
+
+        wavlm_layer (int):
+            WavLM layer to use for feature extraction.
+
+        topk (int):
+            k in the kNN -- the number of nearest neighbors to average over
+    """
+
+    model: str = "knnvc"
+    model_args: KNNVCArgs = field(default_factory=KNNVCArgs)
+    audio: KNNVCAudioConfig = field(default_factory=KNNVCAudioConfig)
+
+    wavlm_layer: int = 6
+    topk: int = 4

--- a/TTS/vc/configs/shared_configs.py
+++ b/TTS/vc/configs/shared_configs.py
@@ -6,7 +6,7 @@ from TTS.config import BaseAudioConfig, BaseDatasetConfig, BaseTrainingConfig
 
 @dataclass
 class BaseVCConfig(BaseTrainingConfig):
-    """Shared parameters among all the tts models.
+    """Shared parameters among all the VC models.
 
     Args:
 

--- a/TTS/vc/layers/freevc/speaker_encoder/speaker_encoder.py
+++ b/TTS/vc/layers/freevc/speaker_encoder/speaker_encoder.py
@@ -115,7 +115,7 @@ class SpeakerEncoder(nn.Module):
 
         return wav_slices, mel_slices
 
-    def embed_utterance(self, wav: np.ndarray, return_partials=False, rate=1.3, min_coverage=0.75):
+    def embed_utterance(self, wav: np.ndarray, return_partials=False, rate=1.3, min_coverage=0.75) -> torch.Tensor:
         """
         Computes an embedding for a single utterance. The utterance is divided in partial
         utterances and an embedding is computed for each. The complete utterance embedding is the

--- a/TTS/vc/layers/freevc/wavlm/__init__.py
+++ b/TTS/vc/layers/freevc/wavlm/__init__.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 model_uri = "https://github.com/coqui-ai/TTS/releases/download/v0.13.0_models/WavLM-Large.pt"
 
 
-def get_wavlm(device="cpu"):
+def get_wavlm(device="cpu") -> WavLM:
     """Download the model and return the model object."""
 
     output_path = get_user_data_dir("tts")

--- a/TTS/vc/layers/freevc/wavlm/wavlm.py
+++ b/TTS/vc/layers/freevc/wavlm/wavlm.py
@@ -9,7 +9,7 @@
 
 import logging
 import math
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -322,7 +322,7 @@ class WavLM(nn.Module):
         ret_conv: bool = False,
         output_layer: Optional[int] = None,
         ret_layer_results: bool = False,
-    ):
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         if self.feature_grad_mult > 0:
             features = self.feature_extractor(source)
             if self.feature_grad_mult != 1.0:

--- a/TTS/vc/models/__init__.py
+++ b/TTS/vc/models/__init__.py
@@ -1,7 +1,10 @@
 import importlib
 import logging
 import re
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
+
+from TTS.vc.configs.shared_configs import BaseVCConfig
+from TTS.vc.models.base_vc import BaseVC
 
 logger = logging.getLogger(__name__)
 
@@ -9,7 +12,11 @@ logger = logging.getLogger(__name__)
 def setup_model(config: BaseVCConfig) -> BaseVC:
     logger.info("Using model: %s", config.model)
     # fetch the right model implementation.
-    if "model" in config and config["model"].lower() == "freevc":
+    if config["model"].lower() == "freevc":
         MyModel = importlib.import_module("TTS.vc.models.freevc").FreeVC
-        model = MyModel.init_from_config(config)
-    return model
+    elif config["model"].lower() == "knnvc":
+        MyModel = importlib.import_module("TTS.vc.models.knnvc").KNNVC
+    else:
+        msg = f"Model {config.model} does not exist!"
+        raise ValueError(msg)
+    return MyModel.init_from_config(config)

--- a/TTS/vc/models/__init__.py
+++ b/TTS/vc/models/__init__.py
@@ -6,10 +6,10 @@ from typing import Dict, List, Union
 logger = logging.getLogger(__name__)
 
 
-def setup_model(config: "Coqpit", samples: Union[List[List], List[Dict]] = None) -> "BaseVC":
+def setup_model(config: BaseVCConfig) -> BaseVC:
     logger.info("Using model: %s", config.model)
     # fetch the right model implementation.
     if "model" in config and config["model"].lower() == "freevc":
         MyModel = importlib.import_module("TTS.vc.models.freevc").FreeVC
-        model = MyModel.init_from_config(config, samples)
+        model = MyModel.init_from_config(config)
     return model

--- a/TTS/vc/models/base_vc.py
+++ b/TTS/vc/models/base_vc.py
@@ -37,7 +37,7 @@ class BaseVC(BaseTrainerModel):
     def __init__(
         self,
         config: Coqpit,
-        ap: AudioProcessor,
+        ap: Optional[AudioProcessor] = None,
         speaker_manager: Optional[SpeakerManager] = None,
         language_manager: Optional[LanguageManager] = None,
     ) -> None:
@@ -51,7 +51,7 @@ class BaseVC(BaseTrainerModel):
     def _set_model_args(self, config: Coqpit) -> None:
         """Setup model args based on the config type (`ModelConfig` or `ModelArgs`).
 
-        `ModelArgs` has all the fields reuqired to initialize the model architecture.
+        `ModelArgs` has all the fields required to initialize the model architecture.
 
         `ModelConfig` has all the fields required for training, inference and containes `ModelArgs`.
 

--- a/TTS/vc/models/freevc.py
+++ b/TTS/vc/models/freevc.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Tuple
 
 import librosa
 import numpy as np
@@ -477,7 +477,7 @@ class FreeVC(BaseVC):
     def eval_step(): ...
 
     @staticmethod
-    def init_from_config(config: FreeVCConfig, samples: Union[List[List], List[Dict]] = None):
+    def init_from_config(config: FreeVCConfig) -> "FreeVC":
         model = FreeVC(config)
         return model
 

--- a/TTS/vc/models/freevc.py
+++ b/TTS/vc/models/freevc.py
@@ -233,7 +233,7 @@ class SpeakerEncoder(torch.nn.Module):
 class FreeVC(BaseVC):
     """
 
-    Papaer::
+    Paper::
         https://arxiv.org/abs/2210.15418#
 
     Paper Abstract::

--- a/TTS/vc/models/freevc.py
+++ b/TTS/vc/models/freevc.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import librosa
 import numpy as np
@@ -386,7 +386,7 @@ class FreeVC(BaseVC):
         return o, ids_slice, spec_mask, (z, z_p, m_p, logs_p, m_q, logs_q)
 
     @torch.inference_mode()
-    def inference(self, c, g=None, mel=None, c_lengths=None):
+    def inference(self, c, g=None, c_lengths=None):
         """
         Inference pass of the model
 
@@ -401,9 +401,6 @@ class FreeVC(BaseVC):
         """
         if c_lengths is None:
             c_lengths = (torch.ones(c.size(0)) * c.size(-1)).to(c.device)
-        if not self.use_spk:
-            g = self.enc_spk.embed_utterance(mel)
-            g = g.unsqueeze(-1)
         z_p, m_p, logs_p, c_mask = self.enc_p(c, c_lengths)
         z = self.flow(z_p, c_mask, g=g, reverse=True)
         o = self.dec(z * c_mask, g=g)
@@ -434,45 +431,47 @@ class FreeVC(BaseVC):
         return wav.float()
 
     @torch.inference_mode()
-    def voice_conversion(self, src, tgt):
+    def voice_conversion(self, src: Union[str, torch.Tensor], tgt: list[Union[str, torch.Tensor]]):
         """
         Voice conversion pass of the model.
 
         Args:
             src (str or torch.Tensor): Source utterance.
-            tgt (str or torch.Tensor): Target utterance.
+            tgt (list of str or torch.Tensor): Target utterances.
 
         Returns:
             torch.Tensor: Output tensor.
         """
 
-        wav_tgt = self.load_audio(tgt).cpu().numpy()
-        wav_tgt, _ = librosa.effects.trim(wav_tgt, top_db=20)
-
-        if self.config.model_args.use_spk:
-            g_tgt = self.enc_spk_ex.embed_utterance(wav_tgt)[None, :, None]
-        else:
-            wav_tgt = torch.from_numpy(wav_tgt).unsqueeze(0).to(self.device)
-            mel_tgt = mel_spectrogram_torch(
-                wav_tgt,
-                self.config.audio.filter_length,
-                self.config.audio.n_mel_channels,
-                self.config.audio.input_sample_rate,
-                self.config.audio.hop_length,
-                self.config.audio.win_length,
-                self.config.audio.mel_fmin,
-                self.config.audio.mel_fmax,
-            )
         # src
         wav_src = self.load_audio(src)
         c = self.extract_wavlm_features(wav_src[None, :])
 
-        if self.config.model_args.use_spk:
-            audio = self.inference(c, g=g_tgt)
-        else:
-            audio = self.inference(c, mel=mel_tgt.transpose(1, 2))
-        audio = audio[0][0].data.cpu().float().numpy()
-        return audio
+        # tgt
+        g_tgts = []
+        for tg in tgt:
+            wav_tgt = self.load_audio(tg).cpu().numpy()
+            wav_tgt, _ = librosa.effects.trim(wav_tgt, top_db=20)
+
+            if self.config.model_args.use_spk:
+                g_tgts.append(self.enc_spk_ex.embed_utterance(wav_tgt)[None, :, None])
+            else:
+                wav_tgt = torch.from_numpy(wav_tgt).unsqueeze(0).to(self.device)
+                mel_tgt = mel_spectrogram_torch(
+                    wav_tgt,
+                    self.config.audio.filter_length,
+                    self.config.audio.n_mel_channels,
+                    self.config.audio.input_sample_rate,
+                    self.config.audio.hop_length,
+                    self.config.audio.win_length,
+                    self.config.audio.mel_fmin,
+                    self.config.audio.mel_fmax,
+                )
+                g_tgts.append(self.enc_spk.embed_utterance(mel_tgt.transpose(1, 2)).unsqueeze(-1))
+
+        g_tgt = torch.stack(g_tgts).mean(dim=0)
+        audio = self.inference(c, g=g_tgt)
+        return audio[0][0].data.cpu().float().numpy()
 
     def eval_step(): ...
 

--- a/TTS/vc/models/freevc.py
+++ b/TTS/vc/models/freevc.py
@@ -306,10 +306,6 @@ class FreeVC(BaseVC):
 
         self.wavlm = get_wavlm()
 
-    @property
-    def device(self):
-        return next(self.parameters()).device
-
     def load_pretrained_speaker_encoder(self):
         """Load pretrained speaker encoder model as mentioned in the paper."""
         logger.info("Loading pretrained speaker encoder model ...")

--- a/TTS/vc/models/knnvc.py
+++ b/TTS/vc/models/knnvc.py
@@ -172,7 +172,7 @@ class KNNVC(BaseVC):
     def voice_conversion(
         self,
         source: PathOrTensor,
-        target: Union[PathOrTensor, list[PathOrTensor]],
+        target: list[PathOrTensor],
         topk: Optional[int] = None,
     ) -> torch.Tensor:
         if not isinstance(target, list):

--- a/TTS/vc/models/knnvc.py
+++ b/TTS/vc/models/knnvc.py
@@ -1,0 +1,182 @@
+import logging
+import os
+from typing import Any, Optional, Union
+
+import torch
+import torch.nn.functional as F
+import torchaudio
+from coqpit import Coqpit
+from typing_extensions import TypeAlias
+
+from TTS.vc.configs.knnvc_config import KNNVCConfig
+from TTS.vc.layers.freevc.wavlm import get_wavlm
+from TTS.vc.models.base_vc import BaseVC
+
+logger = logging.getLogger(__name__)
+
+PathOrTensor: TypeAlias = Union[str, os.PathLike[Any], torch.Tensor]
+
+
+class KNNVC(BaseVC):
+    """
+    Paper::
+        https://arxiv.org/abs/2305.18975
+
+    Paper Abstract::
+        Any-to-any voice conversion aims to transform source speech
+        into a target voice with just a few examples of the target speaker as a
+        reference. Recent methods produce convincing conversions, but at the cost of
+        increased complexity -- making results difficult to reproduce and build on.
+        Instead, we keep it simple. We propose k-nearest neighbors voice conversion
+        (kNN-VC): a straightforward yet effective method for any-to-any conversion.
+        First, we extract self-supervised representations of the source and reference
+        speech. To convert to the target speaker, we replace each frame of the source
+        representation with its nearest neighbor in the reference. Finally, a pretrained
+        vocoder synthesizes audio from the converted representation. Objective and
+        subjective evaluations show that kNN-VC improves speaker similarity with similar
+        intelligibility scores to existing methods.
+
+    Samples::
+        https://bshall.github.io/knn-vc
+
+    Original code::
+        https://github.com/bshall/knn-vc
+
+    Examples:
+        >>> from TTS.vc.configs.knnvc_config import KNNVCConfig
+        >>> from TTS.vc.models.knnvc import KNNVC
+        >>> config = KNNVCConfig()
+        >>> model = KNNVC(config)
+    """
+
+    def __init__(self, config: Coqpit):
+        super().__init__(config)
+        self.ssl_dim = self.args.ssl_dim
+        self.wavlm = get_wavlm()
+
+    @staticmethod
+    def init_from_config(config: KNNVCConfig) -> "KNNVC":
+        return KNNVC(config)
+
+    @torch.inference_mode()
+    def get_features(self, audio: PathOrTensor, vad_trigger_level=0) -> torch.Tensor:
+        """Return features for the given waveform with output shape (seq_len, dim).
+
+        Optionally perform VAD trimming on start/end with `vad_trigger_level`.
+        """
+        # load audio
+        if isinstance(audio, torch.Tensor):
+            x: torch.Tensor = audio
+            sr = self.config.audio.sample_rate
+            if x.dim() == 1:
+                x = x[None]
+        else:
+            x, sr = torchaudio.load(audio, normalize=True)
+
+        if not sr == self.config.audio.sample_rate:
+            logger.info(f"Resampling {sr} to {self.config.audio.sample_rate} in {audio}")
+            x = torchaudio.functional.resample(x, orig_freq=sr, new_freq=self.config.audio.sample_rate)
+            sr = self.config.audio.sample_rate
+
+        # trim silence from front and back
+        if vad_trigger_level > 1e-3:
+            transform = torchaudio.transforms.Vad(sample_rate=sr, trigger_level=vad_trigger_level)
+            x_front_trim = transform(x)
+            waveform_reversed = torch.flip(x_front_trim, (-1,))
+            waveform_reversed_front_trim = transform(waveform_reversed)
+            x = torch.flip(waveform_reversed_front_trim, (-1,))
+
+        # extract the representation of each layer
+        wav_input_16khz = x.to(self.device)
+        features = self.wavlm.extract_features(
+            wav_input_16khz, output_layer=self.config.wavlm_layer, ret_layer_results=False
+        )[0]
+        return features.squeeze(0)
+
+    def get_matching_set(self, wavs: list[PathOrTensor], vad_trigger_level=7) -> torch.Tensor:
+        """Get concatenated wavlm features for the matching set using all waveforms in `wavs`.
+
+        Wavs are specified as either a list of paths or list of loaded waveform tensors of
+        shape (channels, T), assumed to be of 16kHz sample rate.
+        """
+        feats = []
+        for p in wavs:
+            feats.append(self.get_features(p, vad_trigger_level=vad_trigger_level))
+
+        feats = torch.concat(feats, dim=0).cpu()
+        return feats
+
+    @staticmethod
+    def fast_cosine_dist(source_feats: torch.Tensor, matching_pool: torch.Tensor) -> torch.Tensor:
+        """Like torch.cdist, but fixed dim=-1 and for cosine distance."""
+        source_norms = torch.norm(source_feats, p=2, dim=-1)
+        matching_norms = torch.norm(matching_pool, p=2, dim=-1)
+        dotprod = (
+            -(torch.cdist(source_feats[None], matching_pool[None], p=2)[0] ** 2)
+            + source_norms[:, None] ** 2
+            + matching_norms[None] ** 2
+        )
+        dotprod /= 2
+
+        dists = 1 - (dotprod / (source_norms[:, None] * matching_norms[None]))
+        return dists
+
+    @torch.inference_mode()
+    def match(
+        self,
+        query_seq: torch.Tensor,
+        matching_set: torch.Tensor,
+        synth_set: Optional[torch.Tensor] = None,
+        topk: Optional[int] = None,
+        target_duration: Optional[float] = None,
+    ) -> torch.Tensor:
+        """Given `query_seq`, `matching_set`, and `synth_set` tensors of shape (N, dim), perform kNN regression matching
+        with k=`topk`.
+
+        Args:
+            `query_seq`: Tensor (N1, dim) of the input/source query features.
+            `matching_set`: Tensor (N2, dim) of the matching set used as the 'training set' for the kNN algorithm.
+            `synth_set`: optional Tensor (N2, dim) corresponding to the matching set. We use the matching set to assign
+                         each query vector to a vector in the matching set, and then use the corresponding vector from
+                         the synth set during HiFiGAN synthesis.
+                         By default, and for best performance, this should be identical to the matching set.
+            `topk`: k in the kNN -- the number of nearest neighbors to average over.
+            `target_duration`: if set to a float, interpolate waveform duration to be equal to this value in seconds.
+
+        Returns:
+            - converted features (1, N, dim)
+        """
+        if topk is None:
+            topk = self.config.topk
+        synth_set = matching_set.to(self.device) if synth_set is None else synth_set.to(self.device)
+        matching_set = matching_set.to(self.device)
+        query_seq = query_seq.to(self.device)
+
+        if target_duration is not None:
+            target_samples = int(target_duration * self.config.audio.sample_rate)
+            scale_factor = (target_samples / self.hop_length) / query_seq.shape[0]  # n_targ_feats / n_input_feats
+            query_seq = F.interpolate(query_seq.T[None], scale_factor=scale_factor, mode="linear")[0].T
+
+        dists = self.fast_cosine_dist(query_seq, matching_set)
+        best = dists.topk(k=topk, largest=False, dim=-1)
+        out_feats = synth_set[best.indices].mean(dim=1)
+        return out_feats.unsqueeze(0)
+
+    def load_checkpoint(self, vc_config: KNNVCConfig, _vc_checkpoint: Union[str, os.PathLike[Any]]) -> None:
+        """kNN-VC does not use checkpoints."""
+
+    def forward(self) -> None: ...
+    def inference(self) -> None: ...
+
+    @torch.inference_mode()
+    def voice_conversion(
+        self,
+        source: PathOrTensor,
+        target: Union[PathOrTensor, list[PathOrTensor]],
+        topk: Optional[int] = None,
+    ) -> torch.Tensor:
+        if not isinstance(target, list):
+            target = [target]
+        source_features = self.get_features(source)
+        matching_set = self.get_matching_set(target)
+        return self.match(source_features, matching_set, topk=topk)

--- a/TTS/vc/models/openvoice.py
+++ b/TTS/vc/models/openvoice.py
@@ -174,10 +174,6 @@ class OpenVoice(BaseVC):
 
         self.ref_enc = ReferenceEncoder(self.spec_channels, self.gin_channels)
 
-    @property
-    def device(self) -> torch.device:
-        return next(self.parameters()).device
-
     @staticmethod
     def init_from_config(config: OpenVoiceConfig) -> "OpenVoice":
         return OpenVoice(config)

--- a/TTS/vocoder/configs/hifigan_config.py
+++ b/TTS/vocoder/configs/hifigan_config.py
@@ -5,7 +5,7 @@ from TTS.vocoder.configs.shared_configs import BaseGANVocoderConfig
 
 @dataclass
 class HifiganConfig(BaseGANVocoderConfig):
-    """Defines parameters for FullBand MelGAN vocoder.
+    """Defines parameters for HifiGAN vocoder.
 
     Example:
 

--- a/TTS/vocoder/models/__init__.py
+++ b/TTS/vocoder/models/__init__.py
@@ -5,11 +5,13 @@ import re
 from coqpit import Coqpit
 
 from TTS.utils.generic_utils import to_camel
+from TTS.vocoder.configs.shared_configs import BaseGANVocoderConfig, BaseVocoderConfig
+from TTS.vocoder.models.base_vocoder import BaseVocoder
 
 logger = logging.getLogger(__name__)
 
 
-def setup_model(config: Coqpit):
+def setup_model(config: BaseVocoderConfig) -> BaseVocoder:
     """Load models directly from configuration."""
     if "discriminator_model" in config and "generator_model" in config:
         MyModel = importlib.import_module("TTS.vocoder.models.gan")
@@ -26,12 +28,12 @@ def setup_model(config: Coqpit):
             try:
                 MyModel = getattr(MyModel, to_camel(config.model))
             except ModuleNotFoundError as e:
-                raise ValueError(f"Model {config.model} not exist!") from e
+                raise ValueError(f"Model {config.model} does not exist!") from e
     logger.info("Vocoder model: %s", config.model)
     return MyModel.init_from_config(config)
 
 
-def setup_generator(c):
+def setup_generator(c: BaseGANVocoderConfig):
     """TODO: use config object as arguments"""
     logger.info("Generator model: %s", c.generator_model)
     MyModel = importlib.import_module("TTS.vocoder.models." + c.generator_model.lower())
@@ -94,8 +96,8 @@ def setup_generator(c):
     return model
 
 
-def setup_discriminator(c):
-    """TODO: use config objekt as arguments"""
+def setup_discriminator(c: BaseGANVocoderConfig):
+    """TODO: use config object as arguments"""
     logger.info("Discriminator model: %s", c.discriminator_model)
     if "parallel_wavegan" in c.discriminator_model:
         MyModel = importlib.import_module("TTS.vocoder.models.parallel_wavegan_discriminator")

--- a/TTS/vocoder/models/__init__.py
+++ b/TTS/vocoder/models/__init__.py
@@ -40,7 +40,8 @@ def setup_generator(c: BaseGANVocoderConfig):
     MyModel = getattr(MyModel, to_camel(c.generator_model))
     # this is to preserve the Wavernn class name (instead of Wavernn)
     if c.generator_model.lower() in "hifigan_generator":
-        model = MyModel(in_channels=c.audio["num_mels"], out_channels=1, **c.generator_model_params)
+        c.generator_model_params["in_channels"] = c.generator_model_params.get("in_channels", c.audio["num_mels"])
+        model = MyModel(out_channels=1, **c.generator_model_params)
     elif c.generator_model.lower() in "melgan_generator":
         model = MyModel(
             in_channels=c.audio["num_mels"],
@@ -106,7 +107,7 @@ def setup_discriminator(c: BaseGANVocoderConfig):
     MyModel = getattr(MyModel, to_camel(c.discriminator_model.lower()))
     if c.discriminator_model in "hifigan_discriminator":
         model = MyModel()
-    if c.discriminator_model in "random_window_discriminator":
+    elif c.discriminator_model in "random_window_discriminator":
         model = MyModel(
             cond_channels=c.audio["num_mels"],
             hop_length=c.audio["hop_length"],
@@ -115,7 +116,7 @@ def setup_discriminator(c: BaseGANVocoderConfig):
             cond_disc_out_channels=c.discriminator_model_params["cond_disc_out_channels"],
             window_sizes=c.discriminator_model_params["window_sizes"],
         )
-    if c.discriminator_model in "melgan_multiscale_discriminator":
+    elif c.discriminator_model in "melgan_multiscale_discriminator":
         model = MyModel(
             in_channels=1,
             out_channels=1,
@@ -124,7 +125,7 @@ def setup_discriminator(c: BaseGANVocoderConfig):
             max_channels=c.discriminator_model_params["max_channels"],
             downsample_factors=c.discriminator_model_params["downsample_factors"],
         )
-    if c.discriminator_model == "residual_parallel_wavegan_discriminator":
+    elif c.discriminator_model == "residual_parallel_wavegan_discriminator":
         model = MyModel(
             in_channels=1,
             out_channels=1,
@@ -139,7 +140,7 @@ def setup_discriminator(c: BaseGANVocoderConfig):
             nonlinear_activation="LeakyReLU",
             nonlinear_activation_params={"negative_slope": 0.2},
         )
-    if c.discriminator_model == "parallel_wavegan_discriminator":
+    elif c.discriminator_model == "parallel_wavegan_discriminator":
         model = MyModel(
             in_channels=1,
             out_channels=1,
@@ -151,6 +152,8 @@ def setup_discriminator(c: BaseGANVocoderConfig):
             nonlinear_activation_params={"negative_slope": 0.2},
             bias=True,
         )
-    if c.discriminator_model == "univnet_discriminator":
+    elif c.discriminator_model == "univnet_discriminator":
         model = MyModel()
+    else:
+        raise NotImplementedError(f"Model {c.discriminator_model} not implemented!")
     return model

--- a/TTS/vocoder/models/hifigan_generator.py
+++ b/TTS/vocoder/models/hifigan_generator.py
@@ -179,6 +179,7 @@ class HifiganGenerator(torch.nn.Module):
         conv_post_weight_norm=True,
         conv_post_bias=True,
         cond_in_each_up_layer=False,
+        pre_linear=None,
     ):
         r"""HiFiGAN Generator with Multi-Receptive Field Fusion (MRF)
 
@@ -198,6 +199,7 @@ class HifiganGenerator(torch.nn.Module):
                 for each consecutive upsampling layer.
             upsample_factors (List[int]): upsampling factors (stride) for each upsampling layer.
             inference_padding (int): constant padding applied to the input at inference time. Defaults to 5.
+            pre_linear (int): If not None, add nn.Linear(pre_linear, in_channels) before the convolutions.
         """
         super().__init__()
         self.inference_padding = inference_padding
@@ -206,6 +208,8 @@ class HifiganGenerator(torch.nn.Module):
         self.cond_in_each_up_layer = cond_in_each_up_layer
 
         # initial upsampling layers
+        if pre_linear is not None:
+            self.lin_pre = nn.Linear(pre_linear, in_channels)
         self.conv_pre = weight_norm(Conv1d(in_channels, upsample_initial_channel, 7, 1, padding=3))
         resblock = ResBlock1 if resblock_type == "1" else ResBlock2
         # upsampling layers
@@ -258,6 +262,9 @@ class HifiganGenerator(torch.nn.Module):
             x: [B, C, T]
             Tensor: [B, 1, T]
         """
+        if hasattr(self, "lin_pre"):
+            x = self.lin_pre(x)
+            x = x.permute(0, 2, 1)
         o = self.conv_pre(x)
         if hasattr(self, "cond_layer"):
             o = o + self.cond_layer(g)

--- a/docs/source/inference.md
+++ b/docs/source/inference.md
@@ -16,6 +16,7 @@ Coqui TTS provides three main methods for inference:
 
 ```{toctree}
 :hidden:
+vc
 server
 marytts
 ```

--- a/docs/source/models/xtts.md
+++ b/docs/source/models/xtts.md
@@ -182,7 +182,7 @@ To use the model API, you need to download the model files and pass config and m
 If you want to be able to `load_checkpoint` with `use_deepspeed=True` and **enjoy the speedup**, you need to install deepspeed first.
 
 ```console
-pip install deepspeed==0.10.3
+pip install deepspeed
 ```
 
 #### Inference parameters

--- a/docs/source/vc.md
+++ b/docs/source/vc.md
@@ -1,0 +1,84 @@
+# Voice conversion
+
+## Overview
+
+Voice conversion (VC) converts the voice in a speech signal from one speaker to
+that of another speaker while preserving the linguistic content. Coqui supports
+both voice conversion on its own, as well as applying it after speech synthesis
+to enable multi-speaker output with single-speaker TTS models.
+
+### Python API
+
+Converting the voice in `source_wav` to the voice of `target_wav` (the latter
+can also be a list of files):
+
+```python
+from TTS.api import TTS
+
+tts = TTS("voice_conversion_models/multilingual/vctk/freevc24").to("cuda")
+tts.voice_conversion_to_file(
+  source_wav="my/source.wav",
+  target_wav="my/target.wav",
+  file_path="output.wav"
+)
+```
+
+Voice cloning by combining TTS and VC. The FreeVC model is used for voice
+conversion after synthesizing speech.
+
+```python
+
+tts = TTS("tts_models/de/thorsten/tacotron2-DDC")
+tts.tts_with_vc_to_file(
+  "Wie sage ich auf Italienisch, dass ich dich liebe?",
+  speaker_wav=["target1.wav", "target2.wav"],
+  file_path="output.wav"
+)
+```
+
+Some models, including [XTTS](models/xtts.md), support voice cloning directly
+and a separate voice conversion step is not necessary:
+
+```python
+tts = TTS("tts_models/multilingual/multi-dataset/xtts_v2").to("cuda")
+wav = tts.tts(
+  text="Hello world!",
+  speaker_wav="my/cloning/audio.wav",
+  language="en"
+)
+```
+
+### CLI
+
+```sh
+tts --out_path output/path/speech.wav \
+    --model_name "<language>/<dataset>/<model_name>" \
+    --source_wav <path/to/speaker/wav> \
+    --target_wav <path/to/reference/wav1> <path/to/reference/wav2>
+```
+
+## Pretrained models
+
+Coqui includes the following pretrained voice conversion models. Training is not
+supported.
+
+### FreeVC
+
+- `voice_conversion_models/multilingual/vctk/freevc24`
+
+Adapted from: https://github.com/OlaWod/FreeVC
+
+### kNN-VC
+
+- `voice_conversion_models/multilingual/multi-dataset/knnvc`
+
+At least 1-5 minutes of target speaker data are recommended.
+
+Adapted from: https://github.com/bshall/knn-vc
+
+### OpenVoice
+
+- `voice_conversion_models/multilingual/multi-dataset/openvoice_v1`
+- `voice_conversion_models/multilingual/multi-dataset/openvoice_v2`
+
+Adapted from: https://github.com/myshell-ai/OpenVoice

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,4 +1,14 @@
-dependencies = ["torch", "gdown", "pysbd", "gruut", "anyascii", "pypinyin", "coqpit", "mecab-python3", "unidic-lite"]
+dependencies = [
+    "torch",
+    "gdown",
+    "pysbd",
+    "gruut",
+    "anyascii",
+    "pypinyin",
+    "coqpit-config",
+    "mecab-python3",
+    "unidic-lite",
+]
 import torch
 
 from TTS.utils.manage import ModelManager
@@ -39,5 +49,5 @@ def tts(model_name="tts_models/en/ljspeech/tacotron2-DCA", vocoder_name=None, us
 
 
 if __name__ == "__main__":
-    synthesizer = torch.hub.load("coqui-ai/TTS:dev", "tts", source="github")
+    synthesizer = torch.hub.load("idiap/coqui-ai-TTS:dev", "tts", source="github")
     synthesizer.tts("This is a test!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coqui-tts"
-version = "0.25.1"
+version = "0.25.2"
 description = "Deep learning for Text to Speech."
 readme = "README.md"
 requires-python = ">=3.9, <3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     "pyyaml>=6.0",
     "fsspec[http]>=2023.6.0",
     "packaging>=23.1",
+    "typing_extensions>=4.10",
     # Inference
     "pysbd>=0.3.4",
     # Training

--- a/tests/zoo_tests/test_models.py
+++ b/tests/zoo_tests/test_models.py
@@ -71,8 +71,9 @@ def test_models(tmp_path, model_name, manager):
         run_main(main, [*args, "--text", "This is an example.", *speaker_arg, *language_arg])
     elif "voice_conversion_models" in model_name:
         speaker_wav = os.path.join(get_tests_data_path(), "ljspeech", "wavs", "LJ001-0001.wav")
-        reference_wav = os.path.join(get_tests_data_path(), "ljspeech", "wavs", "LJ001-0032.wav")
-        run_main(main, [*args, "--source_wav", speaker_wav, "--target_wav", reference_wav])
+        reference_wav1 = os.path.join(get_tests_data_path(), "ljspeech", "wavs", "LJ001-0028.wav")
+        reference_wav2 = os.path.join(get_tests_data_path(), "ljspeech", "wavs", "LJ001-0032.wav")
+        run_main(main, [*args, "--source_wav", speaker_wav, "--target_wav", reference_wav1, reference_wav2])
     else:
         # only download the model
         manager.download_model(model_name)


### PR DESCRIPTION
## New voice conversion model
- Paper: https://www.isca-archive.org/interspeech_2023/baas23_interspeech.html
- Original code: https://github.com/bshall/knn-vc

## Usage
```python
from TTS.api import TTS

knnvc = TTS("voice_conversion_models/multilingual/multi-dataset/knnvc")
knnvc.voice_conversion_to_file("source.wav", ["target1.wav", "target2.wav", ...], "output.wav")
```

By default the prematched vocoder is used. For the non-prematched version:
```python
knnvc = TTS(
    "voice_conversion_models/multilingual/multi-dataset/knnvc", 
    vocoder_name="vocoder_models/en/librispeech100/wavlm-hifigan"
)
```

CLI:
```bash
tts --model_name voice_conversion_models/multilingual/multi-dataset/knnvc \
    --source_wav source.wav \
    --target_wav target1.wav target2.wav ...
```

## Internals
The vocoder models are the same as the [original ones](https://github.com/bshall/knn-vc/releases/tag/v0.1), but the model names and configs were modified with the following code to be compatible with Coqui and republished in https://github.com/idiap/coqui-ai-TTS/releases/tag/v0.25.2_models:
```python
import torch
from TTS.vocoder.configs.hifigan_config import HifiganConfig

m = torch.load("prematch_g_02500000.pt", map_location="cpu")
m["model_disc"] = None
m["model"] = m.pop("generator")
torch.save(m, "model.pth")

hifigan_config = HifiganConfig()
hifigan_config["audio"]["sample_rate"] = 16000
hifigan_config["generator_model_params"]["inference_padding"] = 0
hifigan_config["generator_model_params"]["pre_linear"] = 1024
hifigan_config["generator_model_params"]["in_channels"] = 512
hifigan_config["generator_model_params"]["upsample_factors"] = [10, 8, 2, 2]
hifigan_config["generator_model_params"]["upsample_kernel_sizes"] = [20, 16, 4, 4]
hifigan_config.save_json("config.json")
```