### PR TITLE
fix(openvoice): correctly set utterance length

### DIFF
--- a/TTS/vc/models/openvoice.py
+++ b/TTS/vc/models/openvoice.py
@@ -226,7 +226,7 @@ class OpenVoice(BaseVC):
     def _set_x_lengths(x: torch.Tensor, aux_input: Mapping[str, Optional[torch.Tensor]]) -> torch.Tensor:
         if "x_lengths" in aux_input and aux_input["x_lengths"] is not None:
             return aux_input["x_lengths"]
-        return torch.tensor(x.shape[1:2]).to(x.device)
+        return torch.tensor(x.shape[-1:]).to(x.device)
 
     @torch.inference_mode()
     def inference(


### PR DESCRIPTION
Wrong dimension was used previously. Fixes #234