### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 .git/
+.venv/
 Dockerfile
+dockerfiles/
 build/
 dist/
 TTS.egg-info/

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,8 +32,8 @@ jobs:
       matrix:
         arch: ["amd64"]
         base:
-        - "nvidia/cuda:11.8.0-base-ubuntu22.04" # GPU enabled
-        - "python:3.10.8-slim" # CPU only
+        - "nvidia/cuda:12.8.1-base-ubuntu24.04" # GPU enabled
+        - "python:3.12-slim" # CPU only
     steps:
       - uses: actions/checkout@v4
       - name: Log in to the Container registry
@@ -49,7 +49,7 @@ jobs:
           base="ghcr.io/idiap/coqui-tts"
           tags="" # PR build
 
-          if [[ ${{ matrix.base }} = "python:3.10.8-slim" ]]; then
+          if [[ ${{ matrix.base }} = "python:3.12-slim" ]]; then
             base="ghcr.io/idiap/coqui-tts-cpu"
           fi
 
@@ -87,7 +87,7 @@ jobs:
       matrix:
         arch: ["amd64"]
         base:
-        - "nvidia/cuda:11.8.0-base-ubuntu22.04" # GPU enabled
+        - "nvidia/cuda:12.8.1-base-ubuntu24.04" # GPU enabled
     steps:
       - uses: actions/checkout@v4
       - name: Log in to the Container registry
@@ -103,7 +103,7 @@ jobs:
           base="ghcr.io/idiap/coqui-tts-dev"
           tags="" # PR build
 
-          if [[ ${{ matrix.base }} = "python:3.10.8-slim" ]]; then
+          if [[ ${{ matrix.base }} = "python:3.12-slim" ]]; then
             base="ghcr.io/idiap/coqui-tts-dev-cpu"
           fi
 

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -22,7 +22,7 @@ jobs:
             exit 1
           fi
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install
       - name: Build sdist and wheel
         run: uv build
       - name: Test installation of sdist and wheel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         subset: ["data_tests", "inference_tests", "test_aux", "test_text"]
     steps:
       - uses: actions/checkout@v4
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.13"]
         shard: [0, 1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
         partition: ["0", "1", "2"]
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=nvidia/cuda:11.8.0-base-ubuntu22.04
+ARG BASE=nvidia/cuda:12.8.1-base-ubuntu24.04
 FROM ${BASE}
 
 RUN apt-get update && \
@@ -17,7 +17,7 @@ RUN pip3 install -U pip setuptools wheel
 RUN pip3 install llvmlite --ignore-installed
 
 # Install Dependencies:
-RUN pip3 install torch torchaudio --extra-index-url https://download.pytorch.org/whl/cu118
+RUN pip3 install torch torchaudio --extra-index-url https://download.pytorch.org/whl/cu128
 RUN rm -rf /root/.cache/pip
 
 # Copy TTS repository contents:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,31 @@
 ARG BASE=nvidia/cuda:12.8.1-base-ubuntu24.04
 FROM ${BASE}
 
-RUN apt-get update && \
-  apt-get upgrade -y
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y --no-install-recommends \
-    gcc g++ make python3 python3-dev python3-pip \
-    python3-venv python3-wheel espeak-ng \
-    libsndfile1-dev libc-dev curl && \
+    gcc g++ make python3 python3-dev \
+    espeak-ng libsndfile1-dev libc-dev && \
   rm -rf /var/lib/apt/lists/*
 
-# Install Rust compiler (to build sudachipy for Mac)
-RUN curl --proto '=https' --tlsv1.2 -sSf "https://sh.rustup.rs" | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:0.8.15 /uv /uvx /bin/
+ENV UV_NO_CACHE=1 \
+    UV_TORCH_BACKEND=auto
 
-RUN pip3 install -U pip setuptools wheel
-RUN pip3 install llvmlite --ignore-installed
+RUN uv venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv PATH="/opt/venv/bin:$PATH"
 
-# Install Dependencies:
-RUN pip3 install torch torchaudio --extra-index-url https://download.pytorch.org/whl/cu128
-RUN rm -rf /root/.cache/pip
+WORKDIR /app
 
-# Copy TTS repository contents:
-WORKDIR /root
-COPY . /root
+# Install dependencies first for better caching
+COPY pyproject.toml /app
+RUN uv pip install -r pyproject.toml --extra all
 
-RUN pip3 install -e .[all]
+# Copy the rest of the application
+COPY . /app
+
+# Install the project
+RUN uv pip install -e .
 
 ENTRYPOINT ["tts"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can also help us implement more models.
 <!-- start installation -->
 ## Installation
 
-🐸TTS is tested on Ubuntu 24.04 with **python >= 3.10, < 3.13**, but should also
+🐸TTS is tested on Ubuntu 24.04 with **python >= 3.10, < 3.14**, but should also
 work on Mac and Windows.
 
 If you are only interested in [synthesizing speech](https://coqui-tts.readthedocs.io/en/latest/inference.html) with the pretrained 🐸TTS models, installing from PyPI is the easiest option.

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,4 +1,4 @@
-ARG BASE=nvidia/cuda:11.8.0-base-ubuntu22.04
+ARG BASE=nvidia/cuda:12.8.1-base-ubuntu24.04
 FROM ${BASE}
 
 # Install OS dependencies:
@@ -13,7 +13,7 @@ RUN apt-get install -y --no-install-recommends \
 # Install Major Python Dependencies:
 RUN pip3 install -U pip setuptools
 RUN pip3 install llvmlite --ignore-installed
-RUN pip3 install torch torchaudio --extra-index-url https://download.pytorch.org/whl/cu118
+RUN pip3 install torch torchaudio --extra-index-url https://download.pytorch.org/whl/cu128
 RUN rm -rf /root/.cache/pip
 
 # Copy TTS repository contents:

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -6,18 +6,26 @@ RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y --no-install-recommends \
     gcc g++ \
     make \
-    python3 python3-dev python3-pip python3-venv python3-wheel \
+    python3 python3-dev \
     espeak-ng libsndfile1-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Major Python Dependencies:
-RUN pip3 install -U pip setuptools
-RUN pip3 install llvmlite --ignore-installed
-RUN pip3 install torch torchaudio --extra-index-url https://download.pytorch.org/whl/cu128
-RUN rm -rf /root/.cache/pip
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:0.8.15 /uv /uvx /bin/
+ENV UV_NO_CACHE=1 \
+    UV_TORCH_BACKEND=auto
 
-# Copy TTS repository contents:
-WORKDIR /root
-COPY . /root
+RUN uv venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv PATH="/opt/venv/bin:$PATH"
 
-RUN pip3 install -e .[all,dev]
+WORKDIR /app
+
+# Install dependencies first for better caching
+COPY pyproject.toml /app
+RUN uv pip install -r pyproject.toml --extra all --group dev
+
+# Copy the rest of the application
+COPY . /app
+
+# Install the project
+RUN uv pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dependencies = [
     "torchaudio>=2.1.0,<2.9",
     "soundfile>=0.12.0",
     "librosa>=0.11.0",
+    "numba>=0.58.0",
     "inflect>=5.6.0",
     "tqdm>=4.64.1",
     "anyascii>=0.3.0",
@@ -159,9 +160,6 @@ Discussions = "https://github.com/idiap/coqui-ai-TTS/discussions"
 [project.scripts]
 tts = "TTS.bin.synthesize:main"
 tts-server = "TTS.server.server:main"
-
-[tool.uv]
-constraint-dependencies = ["numba>0.58.0"]
 
 [tool.hatch.build]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dependencies = [
     "gruut[de,es,fr]>=2.4.0",
     # Tortoise
     "einops>=0.6.0",
-    "transformers>=4.52.1",
+    "transformers>=4.52.1,<4.56",
     # Bark
     "encodec>=0.1.1",
     # XTTS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ name = "coqui-tts"
 version = "0.27.1"
 description = "Deep learning for Text to Speech."
 readme = "README.md"
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.10, <3.14"
 license = {text = "MPL-2.0"}
 authors = [
     {name = "Eren Gölge", email = "egolge@coqui.ai"}
@@ -42,7 +42,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
     "Operating System :: POSIX :: Linux",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coqui-tts"
-version = "0.27.1"
+version = "0.27.2"
 description = "Deep learning for Text to Speech."
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/tests/text_tests/test_korean_phonemizer.py
+++ b/tests/text_tests/test_korean_phonemizer.py
@@ -1,4 +1,7 @@
+import sys
 import unittest
+
+import pytest
 
 from TTS.tts.utils.text.korean.phonemizer import korean_text_to_phonemes
 
@@ -17,6 +20,7 @@ _TEST_CASES_EN = """
 """
 
 
+@pytest.mark.skipif(not sys.version_info < (3, 13), reason="Requires Python 3.12 or lower")
 class TestText(unittest.TestCase):
     def test_korean_text_to_phonemes(self):
         for line in _TEST_CASES.strip().split("\n"):

--- a/tests/text_tests/test_phonemizer.py
+++ b/tests/text_tests/test_phonemizer.py
@@ -1,9 +1,11 @@
 import unittest
 
+import pytest
 from packaging.version import Version
 
 from TTS.tts.utils.text.phonemizers import ESpeak, Gruut, JA_JP_Phonemizer, ZH_CN_Phonemizer
 from TTS.tts.utils.text.phonemizers.bangla_phonemizer import BN_Phonemizer
+from TTS.tts.utils.text.phonemizers.espeak_wrapper import _is_tool
 from TTS.tts.utils.text.phonemizers.multi_phonemizer import MultiPhonemizer
 
 EXAMPLE_TEXTs = [
@@ -38,6 +40,7 @@ EXPECTED_ESPEAKNG_PHONEMES = [
 ]
 
 
+@pytest.mark.skipif(not _is_tool("espeak"), reason="espeak not installed")
 class TestEspeakPhonemizer(unittest.TestCase):
     def setUp(self):
         self.phonemizer = ESpeak(language="en-us", backend="espeak")

--- a/tests/text_tests/test_tokenizer.py
+++ b/tests/text_tests/test_tokenizer.py
@@ -12,7 +12,7 @@ class TestTTSTokenizer(unittest.TestCase):
     def setUp(self):
         self.tokenizer = TTSTokenizer(use_phonemes=False, characters=Graphemes())
 
-        self.ph = ESpeak("tr", backend="espeak")
+        self.ph = ESpeak("tr", backend="espeak-ng")
         self.tokenizer_ph = TTSTokenizer(use_phonemes=True, characters=IPAPhonemes(), phonemizer=self.ph)
 
     def test_encode_decode_graphemes(self):
@@ -49,7 +49,7 @@ class TestTTSTokenizer(unittest.TestCase):
         text = "Bu bir Örnek."
         self.tokenizer_ph.use_eos_bos = True
         self.tokenizer_ph.add_blank = True
-        text_ph = "<BOS><BLNK>b<BLNK>ʊ<BLNK> <BLNK>b<BLNK>ɪ<BLNK>r<BLNK> <BLNK>œ<BLNK>r<BLNK>n<BLNK>ˈ<BLNK>ɛ<BLNK>c<BLNK>.<BLNK><EOS>"
+        text_ph = "<BOS><BLNK>b<BLNK>ʊ<BLNK> <BLNK>b<BLNK>ɪ<BLNK>r<BLNK> <BLNK>œ<BLNK>r<BLNK>n<BLNK>ˈ<BLNK>ɛ<BLNK>k<BLNK>.<BLNK><EOS>"
         ids = self.tokenizer_ph.text_to_ids(text)
         text_hat = self.tokenizer_ph.ids_to_text(ids)
         self.assertEqual(text_ph, text_hat)
@@ -92,7 +92,7 @@ class TestTTSTokenizer(unittest.TestCase):
             text_cleaner: str = "phoneme_cleaners"
 
         tokenizer_ph, _ = TTSTokenizer.init_from_config(TokenizerConfig())
-        tokenizer_ph.phonemizer.backend = "espeak"
+        tokenizer_ph.phonemizer.backend = "espeak-ng"
         text = "Bu bir Örnek."
         text_ph = "<BOS>" + self.ph.phonemize(text, separator="") + "<EOS>"
         ids = tokenizer_ph.text_to_ids(text)


### PR DESCRIPTION
Add Python 3.13 support. Dependencies [mojimoji](https://github.com/studio-ousia/mojimoji/issues/27) (via cutlet) and  [python-mecab-ko](https://github.com/jonghwanhyeon/python-mecab-ko/issues/23) (via g2pkk) don't provide 3.13 wheels yet, but since they are only used in optional extras, that is not a major issue.

Also update the Ubuntu/Cuda/Python versions used in the Docker images.

Fixes #108