### PR TITLE
Refactor for compatibility with transformers>=4.47

### DIFF
--- a/TTS/tts/layers/tortoise/arch_utils.py
+++ b/TTS/tts/layers/tortoise/arch_utils.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torchaudio
-from transformers import LogitsWarper
+from transformers import LogitsProcessor
 
 from TTS.tts.layers.tortoise.xtransformers import ContinuousTransformerWrapper, RelativePositionBias
 from TTS.utils.generic_utils import is_pytorch_at_least_2_4
@@ -292,7 +292,7 @@ class CheckpointedXTransformerEncoder(nn.Module):
         return h
 
 
-class TypicalLogitsWarper(LogitsWarper):
+class TypicalLogitsWarper(LogitsProcessor):
     def __init__(
         self,
         mass: float = 0.9,

--- a/TTS/tts/layers/xtts/stream_generator.py
+++ b/TTS/tts/layers/xtts/stream_generator.py
@@ -207,8 +207,8 @@ class NewGenerationMixin(GenerationMixin):
             )
             model_kwargs["attention_mask"] = self._prepare_attention_mask_for_generation(
                 inputs_tensor,
-                generation_config._pad_token_tensor,
-                generation_config._eos_token_tensor,
+                generation_config,
+                model_kwargs,
             )
 
         # decoder-only models should use left-padding for generation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
     "gruut[de,es,fr]>=2.4.0",
     # Tortoise
     "einops>=0.6.0",
-    "transformers>=4.43.0,<=4.46.2",
+    "transformers>=4.47.0",
     # Bark
     "encodec>=0.1.1",
     # XTTS


### PR DESCRIPTION
- original change by @JohnnyStreet in #150 to update the XTTS streaming code
- handle removal of `LogitsWarper` in transformers>=4.49

Fixes #306