### PR TITLE
fix(forward_tts): ensure tensor 'g' is on the same device as 'x'

### DIFF
--- a/TTS/tts/models/forward_tts.py
+++ b/TTS/tts/models/forward_tts.py
@@ -331,7 +331,7 @@ class ForwardTTS(BaseTTS):
         return o_dr
 
     def _forward_encoder(
-        self, x: torch.LongTensor, x_mask: torch.FloatTensor, g: torch.FloatTensor = None
+        self, x: torch.LongTensor, x_mask: torch.FloatTensor, g: torch.FloatTensor | None = None
     ) -> tuple[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.FloatTensor]:
         """Encoding forward pass.
 
@@ -356,7 +356,7 @@ class ForwardTTS(BaseTTS):
             - g: :math:`(B, C)`
         """
         if hasattr(self, "emb_g"):
-            g = g.type(torch.LongTensor)
+            g = g.type(torch.LongTensor).to(x.device)
             g = self.emb_g(g)  # [B, C, 1]
         if g is not None:
             g = g.unsqueeze(-1)


### PR DESCRIPTION
When training a multi-speaker ForwardTTS model with speaker embeddings enabled, the training loop fails with the following error:

```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

This happens because the speaker ID tensor g (from the batch) is on the CPU, while the model’s emb_g embedding layer is on the GPU.

This PR fixes the device mismatch by explicitly moving g to the same device as the input tensor x before calling self.emb_g(g) in _forward_encoder.

