### PR TITLE
Remove Spacy dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN curl --proto '=https' --tlsv1.2 -sSf "https://sh.rustup.rs" | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN pip3 install -U pip setuptools wheel
-RUN pip3 install -U "spacy[ja]<3.8"
 RUN pip3 install llvmlite --ignore-installed
 
 # Install Dependencies:

--- a/TTS/tts/layers/xtts/tokenizer.py
+++ b/TTS/tts/layers/xtts/tokenizer.py
@@ -6,12 +6,6 @@ from functools import cached_property
 
 import torch
 from num2words import num2words
-from spacy.lang.ar import Arabic
-from spacy.lang.en import English
-from spacy.lang.es import Spanish
-from spacy.lang.hi import Hindi
-from spacy.lang.ja import Japanese
-from spacy.lang.zh import Chinese
 from tokenizers import Tokenizer
 
 from TTS.tts.layers.xtts.zh_num2words import TextNorm as zh_num2words
@@ -21,6 +15,15 @@ logger = logging.getLogger(__name__)
 
 
 def get_spacy_lang(lang):
+    try:
+        from spacy.lang.ar import Arabic
+        from spacy.lang.en import English
+        from spacy.lang.es import Spanish
+        from spacy.lang.hi import Hindi
+        from spacy.lang.ja import Japanese
+        from spacy.lang.zh import Chinese
+    except ImportError as e:
+        raise ImportError("enable_text_splitting=True requires Spacy: pip install spacy[ja]") from e
     """Return Spacy language used for sentence splitting."""
     if lang == "zh":
         return Chinese()

--- a/docs/source/marytts.md
+++ b/docs/source/marytts.md
@@ -39,5 +39,25 @@ You can enter the same URLs in your browser and check-out the results there as w
 
 ### How it works and limitations
 
-A classic Mary-TTS server would usually show all installed locales and voices via the corresponding endpoints and accept the parameters `LOCALE` and `VOICE` for processing. For Coqui-TTS we usually start the server with one specific locale and model and thus cannot return all available options. Instead we return the active locale and use the model name as "voice". Since we only have one active model and always want to return a WAV-file, we currently ignore all other processing parameters except `INPUT_TEXT`. Since the gender is not defined for models in Coqui-TTS we always return `u` (undefined).
-We think that this is an acceptable compromise, since users are often only interested in one specific voice anyways, but the API might get extended in the future to support multiple languages and voices at the same time.
+#### Single-speaker models
+
+A classic Mary-TTS server would usually show all installed locales and voices
+via the corresponding endpoints and accept the parameters `LOCALE` and `VOICE`
+for processing. For Coqui-TTS we usually start the server with one specific
+locale and model and thus cannot return all available options. Instead, for
+single-speaker models, we return the active locale and use the model name as
+"voice". Since we only have one active model and always want to return a
+WAV-file, we currently ignore all other processing parameters except
+`INPUT_TEXT`. Since the gender is not defined for models in Coqui-TTS we always
+return `u` (undefined). We think that this is an acceptable compromise, since
+users are often only interested in one specific voice anyways, but the API might
+get extended in the future to support multiple languages and voices at the same
+time.
+
+#### Multi-speaker models
+
+For multi-speaker models, a specific speaker ID can be passed with the `VOICE`
+parameter. The `/voices` endpoint will return all available speaker IDs.
+Alternatively, the server can be started with e.g. `tts-server --model_name
+tts_models/en/vctk/vits --speaker_idx p376` to set a default speaker that will
+be used if the `VOICE` parameter is left out.

--- a/docs/source/models/xtts.md
+++ b/docs/source/models/xtts.md
@@ -197,7 +197,7 @@ pip install deepspeed
 - `top_k`: Lower values mean the decoder produces more "likely" (aka boring) outputs. Defaults to 50.
 - `top_p`: Lower values mean the decoder produces more "likely" (aka boring) outputs. Defaults to 0.8.
 - `speed`: The speed rate of the generated audio. Defaults to 1.0. (can produce artifacts if far from 1.0)
-- `enable_text_splitting`: Whether to split the text into sentences and generate audio for each sentence. It allows you to have infinite input length but might loose important context between sentences. Defaults to True.
+- `enable_text_splitting`: Whether to split the text into sentences and generate audio for each sentence. It allows you to have infinite input length but might loose important context between sentences. Defaults to False.
 
 
 #### Inference

--- a/docs/source/server.md
+++ b/docs/source/server.md
@@ -15,11 +15,16 @@ tts-server --list_models  # list the available models.
 
 Run a TTS model, from the release models list, with its default vocoder.
 If the model you choose is a multi-speaker or multilingual TTS model, you can
-select different speakers and languages on the Web interface and synthesize
-speech.
+select different speakers and languages on the Web interface (default URL:
+http://localhost:5002) and synthesize speech.
 
 ```bash
 tts-server --model_name "<type>/<language>/<dataset>/<model_name>"
+```
+
+It is also possible to set a default speaker for multi-speaker models:
+```bash
+tts-server --model_name tts_models/en/vctk/vits --speaker_idx p376
 ```
 
 Run a TTS and a vocoder model from the released model list. Note that not every vocoder is compatible with every TTS model.
@@ -28,3 +33,13 @@ Run a TTS and a vocoder model from the released model list. Note that not every 
 tts-server --model_name "<type>/<language>/<dataset>/<model_name>" \
            --vocoder_name "<type>/<language>/<dataset>/<model_name>"
 ```
+
+## Parameters
+
+The `/api/tts` endpoint accepts the following parameters:
+
+- `text`: Input text (required)
+- `speaker-id`: Speaker ID (for multi-speaker models)
+- `language-id`: Language ID (for multilingual models)
+- `speaker-wav`: Reference speaker audio file path (for models with voice cloning support)
+- `style-wav`: Style audio file path (for supported models)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ dependencies = [
     "encodec>=0.1.1",
     # XTTS
     "num2words>=0.5.14",
-    "spacy[ja]>=3.8,<4",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coqui-tts"
-version = "0.26.0"
+version = "0.26.1"
 description = "Deep learning for Text to Speech."
 readme = "README.md"
 requires-python = ">=3.10, <3.13"


### PR DESCRIPTION
Spacy will likely be very slow to support Python 3.13, so it's better to let users install it themselves if they need it. Coqui anyway only used it for text splitting in XTTS, which is already disabled by default.