### PR TITLE
fix: don't convert to int to avoid constant value in onnx exports

### DIFF
--- a/TTS/tts/utils/helpers.py
+++ b/TTS/tts/utils/helpers.py
@@ -44,7 +44,7 @@ def sequence_mask(sequence_length: torch.Tensor, max_len: int | None = None) -> 
         - mask: :math:`[B, T_max]`
     """
     if max_len is None:
-        max_len = int(sequence_length.max())
+        max_len = sequence_length.max()
     seq_range = torch.arange(max_len, dtype=sequence_length.dtype, device=sequence_length.device)
     # B x T_max
     return seq_range.unsqueeze(0) < sequence_length.unsqueeze(1)


### PR DESCRIPTION
This value shouldn't be converted to a Python `int` because then it is a constant when exported to onnx, see:
```
TracerWarning: Converting a tensor to a Python integer might cause the trace to be incorrect.
We can't record the data flow of Python values, so this value will be treated as a constant in the
future. This means that the trace might not generalize to other inputs!
```

Fixes #315