### PR TITLE
Bring back compatibility with numpy1

### DIFF
--- a/TTS/__init__.py
+++ b/TTS/__init__.py
@@ -19,14 +19,8 @@ if is_pytorch_at_least_2_4():
     from collections import defaultdict
 
     import numpy as np
-    try:
-        # NumPy ≤ 1.x
-        from numpy.core.multiarray import scalar as _np_scalar
-    except ModuleNotFoundError:
-        # NumPy ≥ 2.0 – public namespace gone, fall back to the shim
-        from numpy._core.multiarray import scalar as _np_scalar
-
     import torch
+    from numpy._core.multiarray import scalar as _np_scalar
 
     from TTS.config.shared_configs import BaseDatasetConfig
     from TTS.tts.configs.xtts_config import XttsConfig

--- a/TTS/__init__.py
+++ b/TTS/__init__.py
@@ -33,7 +33,7 @@ if is_pytorch_at_least_2_4():
     np_core = np._core if version.parse(np.__version__) >= version.parse("2.0.0") else np.core
     torch.serialization.add_safe_globals(
         [
-            np_core,
+            np_core.multiarray.scalar,
             np.dtype,
             np.dtypes.Float64DType,
             _codecs.encode,  # TODO: safe by default from Pytorch 2.5

--- a/TTS/__init__.py
+++ b/TTS/__init__.py
@@ -20,7 +20,7 @@ if is_pytorch_at_least_2_4():
 
     import numpy as np
     import torch
-    from numpy._core.multiarray import scalar as _np_scalar
+    from packaging import version
 
     from TTS.config.shared_configs import BaseDatasetConfig
     from TTS.tts.configs.xtts_config import XttsConfig
@@ -30,9 +30,10 @@ if is_pytorch_at_least_2_4():
     torch.serialization.add_safe_globals([dict, defaultdict, RAdam])
 
     # Bark
+    np_core = np._core if version.parse(np.__version__) >= version.parse("2.0.0") else np.core
     torch.serialization.add_safe_globals(
         [
-            (_np_scalar, "numpy.core.multiarray.scalar"),
+            np_core,
             np.dtype,
             np.dtypes.Float64DType,
             _codecs.encode,  # TODO: safe by default from Pytorch 2.5

--- a/TTS/__init__.py
+++ b/TTS/__init__.py
@@ -19,6 +19,13 @@ if is_pytorch_at_least_2_4():
     from collections import defaultdict
 
     import numpy as np
+    try:
+        # NumPy ≤ 1.x
+        from numpy.core.multiarray import scalar as _np_scalar
+    except ModuleNotFoundError:
+        # NumPy ≥ 2.0 – public namespace gone, fall back to the shim
+        from numpy._core.multiarray import scalar as _np_scalar
+
     import torch
 
     from TTS.config.shared_configs import BaseDatasetConfig
@@ -31,7 +38,7 @@ if is_pytorch_at_least_2_4():
     # Bark
     torch.serialization.add_safe_globals(
         [
-            np._core.multiarray.scalar,
+            (_np_scalar, "numpy.core.multiarray.scalar"),
             np.dtype,
             np.dtypes.Float64DType,
             _codecs.encode,  # TODO: safe by default from Pytorch 2.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classifiers = [
 ]
 dependencies = [
     # Core
-    "numpy>=2",
+    "numpy>=1.26.0",
     "cython>=3.0.0",
     "scipy>=1.13.0",
     "torch>=2.3",


### PR DESCRIPTION
Hello guys, 
First, thanks a lot for maintaining coqui-tts, you all are open source heros!!

# Context 
I've noticed you removed compatibiliy with numpy 1 in the 0.26.1. There are two main problems with that
1. Going from `numpy>=1.25.2,<2.0` to `numpy>=2` is a breaking change that ideally should be avoided in a patch release.
2. Dropping support for numpy1 can cause a lot of compatibility issues for people, since there are still many packages that require numpy<2 (example: [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM/blob/v0.20.0rc3/requirements.txt) even in its most recent release from last week).

# Solution
I propose keeping `numpy>=1.26.0` for now. I did the necessary code changes to make both 1.26 and 2.xx work. Please let me know if you have concerns or any suggestions regarding my changes.