### PR TITLE
feat(server): add OpenAI-compatible endpoint

### DIFF
--- a/TTS/server/server.py
+++ b/TTS/server/server.py
@@ -3,7 +3,6 @@
 """TTS demo server."""
 
 import argparse
-import gc
 import io
 import json
 import logging

--- a/TTS/server/server.py
+++ b/TTS/server/server.py
@@ -73,7 +73,6 @@ def create_argparser() -> argparse.ArgumentParser:
         "--show_details", action=argparse.BooleanOptionalAction, default=False, help="Generate model detail page."
     )
     parser.add_argument("--language_id", type=str, help="language id. Default=en. Can be overridden in request.", default="en")
-    parser.add_argument("--lowvram", action=argparse.BooleanOptionalAction, default=False, help="true to use low vram mode, switches device to cpu when idle.")
     return parser
 
 
@@ -96,10 +95,9 @@ if args.list_models:
 
 device = args.device
 if args.use_cuda:
+    # Only override with "cuda" if user has not already specified a cuda variant, e.g., "cuda:0", "cuda:1"
     if not "cuda" in device:
         device = "cuda"
-
-current_device = device 
 
 # CASE2: load models
 model_name = args.model_name if args.model_path is None else None
@@ -119,43 +117,6 @@ use_gst = api.synthesizer.tts_config.get("use_gst", False)
 supports_cloning = api.synthesizer.tts_config.get("model", "") in ["xtts", "bark"]
 
 app = Flask(__name__)
-
-def handle_vram_change(desired_device: str):
-    current_device = str(api.synthesizer.tts_model.device)
-    if torch.cuda.is_available():
-        if "cuda" in desired_device:
-            if "cuda" not in current_device:
-                api.synthesizer.tts_model.to(desired_device)
-                gc.collect()
-                current_device = desired_device
-        if "cpu" in desired_device:
-            if "cpu" not in current_device:
-                api.synthesizer.tts_model.to(desired_device)
-                torch.cuda.empty_cache()
-                gc.collect()
-                current_device = desired_device
-
-# Move out of vram if low vram mode until ready to generate
-if args.lowvram and "cuda" in device:
-    handle_vram_change("cpu")
-
-# Handle large passages that may throw errors
-def split_sentences_in_text(text: str, lang:str="en") -> list:
-    # Do not split short passages
-    if len(text) <= 175:
-        return [text]
-
-    if not api:
-        return [text]
-    
-    # Use segmenter built into coqui-tts library to split sentences
-    try:
-        api.synthesizer.seg = api.synthesizer._get_segmenter(lang)
-    except Exception as e:
-        logger.info(f"Getting segmenter for language: {lang} failed, defaulting to English.  Reason: {e}.")
-    text_lines = api.synthesizer.split_into_sentences(text)
-    
-    return text_lines
     
 def style_wav_uri_to_dict(style_wav: str) -> str | dict:
     """Transform an uri style_wav, in either a string (path to wav file to be use for style transfer)
@@ -210,8 +171,6 @@ lock = Lock()
 @app.route("/api/tts", methods=["GET", "POST"])
 def tts():
     with lock:
-        if args.lowvram:
-            handle_vram_change(device)
         text = request.headers.get("text") or request.values.get("text", "")
         speaker_idx = (
             request.headers.get("speaker-id") or request.values.get("speaker_id", args.speaker_idx)
@@ -230,18 +189,9 @@ def tts():
         logger.info("Model input: %s", text)
         logger.info("Speaker idx: %s", speaker_idx)
         logger.info("Language idx: %s", language_idx)
-        sentences = split_sentences_in_text(text, language_idx)
-        combined_audio = None
-        for sentence in sentences:
-            wavs = api.tts(sentence, speaker=speaker_idx, language=language_idx, style_wav=style_wav, speaker_wav=speaker_wav)
-            if combined_audio == None:
-                combined_audio = wavs
-            else:
-                combined_audio = combined_audio + wavs
+        wavs = api.tts(text, speaker=speaker_idx, language=language_idx, style_wav=style_wav, speaker_wav=speaker_wav)
         out = io.BytesIO()
-        api.synthesizer.save_wav(combined_audio, out)
-    if args.lowvram:
-        handle_vram_change("cpu")
+        api.synthesizer.save_wav(wavs, out)
     return send_file(out, mimetype="audio/wav")
 
 
@@ -283,8 +233,6 @@ def mary_tts_api_voices():
 def mary_tts_api_process():
     """MaryTTS-compatible /process endpoint"""
     with lock:
-        if args.lowvram:
-            handle_vram_change(device)
         if request.method == "POST":
             data = parse_qs(request.get_data(as_text=True))
             speaker_idx = data.get("VOICE", [args.speaker_idx])[0]
@@ -297,18 +245,9 @@ def mary_tts_api_process():
         logger.info("Model input: %s", text)
         logger.info("Speaker idx: %s", speaker_idx)
         locale=args.model_name.split("/")[1]
-        sentences = split_sentences_in_text(text, locale)
-        combined_audio = None
-        for sentence in sentences:
-            wavs = api.tts(sentence, speaker=speaker_idx)
-            if combined_audio == None:
-                combined_audio = wavs
-            else:
-                combined_audio = combined_audio + wavs
+        wavs = api.tts(text, speaker=speaker_idx)
         out = io.BytesIO()
-        api.synthesizer.save_wav(combined_audio, out)
-    if args.lowvram:
-        handle_vram_change("cpu")
+        api.synthesizer.save_wav(wavs, out)
     return send_file(out, mimetype="audio/wav")
 
 # OpenAI Speech API
@@ -347,40 +286,27 @@ def openai_tts():
     speed  = payload.get("speed", 1.0)
     language_idx = args.language_id if args.language_id else "en"
     
-    # map OpenAI model names to your loaded model
-    # here we ignore payload["model"] since you load at startup
+    # here we ignore payload["model"] since its loaded at startup
 
     with lock:
-        if args.lowvram:
-            handle_vram_change(device)
-        sentences = split_sentences_in_text(text, language_idx)
-        combined_audio = None
-        for sentence in sentences:
-            # if voice is a plain string, assume its a built-in speaker
-            if not voice_type in ["dir", "wav"]:
-                wavs = api.tts(sentence, speaker=voice, language=language_idx, speed=speed)
-            # if its a path to a .wav file, it's a cloning .wav
-            elif voice_type == "wav":
-                wavs = api.tts(sentence, speaker_wav=voice, language=language_idx, speed=speed)
-            # if it's a directory, get all the .wavs inside as a list of cloning .wavs
-            elif voice_type == "dir":
-                voice = Path(voice)
-                voices = [
-                    str(wav_path)
-                    for wav_path in voice.glob("*.wav")
-                    if wav_path.is_file()
-                ]
-                wavs = api.tts(sentence, speaker_wav=voices, language=language_idx, speed=speed)
-            if combined_audio == None:
-                combined_audio = wavs
-            else:
-                combined_audio = combined_audio + wavs
-        wav_io = io.BytesIO()
-        api.synthesizer.save_wav(combined_audio, wav_io)
-        wav_io.seek(0)
-
-        # Load WAV data into tensor
-        waveform, sample_rate = torchaudio.load(wav_io)
+        # if voice is a plain string, assume its a built-in speaker
+        if not voice_type in ["dir", "wav"]:
+            wavs = api.tts(text, speaker=voice, language=language_idx, speed=speed)
+        # if its a path to a .wav file, it's a cloning .wav
+        elif voice_type == "wav":
+            wavs = api.tts(text, speaker_wav=voice, language=language_idx, speed=speed)
+        # if it's a directory, get all the .wavs inside as a list of cloning .wavs
+        elif voice_type == "dir":
+            voice = Path(voice)
+            voices = [
+                str(wav_path)
+                for wav_path in voice.glob("*.wav")
+                if wav_path.is_file()
+            ]
+            wavs = api.tts(text, speaker_wav=voices, language=language_idx, speed=speed)
+        out = io.BytesIO()
+        api.synthesizer.save_wav(wavs, out)
+        out.seek(0)
 
         mimetypes = {
             "wav": "audio/wav",
@@ -392,12 +318,13 @@ def openai_tts():
         }
 
         fmt = fmt.lower()
+        # OpenAI spec defaults to .mp3 if not specified
         mimetype = mimetypes.get(fmt, "mp3")
-        if args.lowvram:
-            handle_vram_change("cpu")
         if fmt == "wav":
-            wav_io.seek(0)
-            return send_file(wav_io, mimetype=mimetype)
+            out.seek(0)
+            return send_file(out, mimetype=mimetype)
+        # If requested format is not .wav, load WAV data into tensor, and convert to desired format
+        waveform, sample_rate = torchaudio.load(out)
         elif fmt == "mp3":
             out_mp3 = io.BytesIO()
             torchaudio.save(out_mp3, waveform, sample_rate, format="mp3")
@@ -427,40 +354,6 @@ def openai_tts():
             return send_file(out_pcm, mimetype=mimetype)
         else:
             return {"error": f"Unsupported format: {fmt}"}, 400
-
-@app.route("/v1/audio/voices", methods=["GET"])
-def openai_list_voices():
-    """
-    GET /v1/audio/voices
-    Returns the list of available voice IDs.
-    """
-    # map api.speakers to OpenAI data schema
-    data = []
-    for v in (api.speakers or []):
-        data.append({
-            "voice_id": v,
-            "language_codes": api.languages if api.is_multi_lingual else ["en"],
-            "name": v,
-            "preview_url": None,
-        })
-    return jsonify({"data": data})
-
-
-@app.route("/v1/models", methods=["GET"])
-def openai_list_models():
-    """
-    GET /v1/models
-    Returns a list of “models” – here we only expose our TTS model.
-    """
-    model_id = args.model_name or os.path.basename(args.model_path or "")
-    return jsonify({
-        "data": [
-            {"id": model_id, "object": "model"}
-        ]
-    })
-
-# ───────────────────────────────────────────────────────────────────────────────
-
 
 def main():
     app.run(debug=args.debug, host="::", port=args.port)

--- a/docs/source/server.md
+++ b/docs/source/server.md
@@ -34,6 +34,16 @@ tts-server --model_name "<type>/<language>/<dataset>/<model_name>" \
            --vocoder_name "<type>/<language>/<dataset>/<model_name>"
 ```
 
+Run a TTS model saved locally using GPU (cuda), supplying a language code for the model (default "en" for English):
+```bash
+tts-server --use_cuda --model_path C:\directory_path\to\model\directory --config_path C:\file_path\to\model\config.json --speakers_file_path C:\file_path\to\model\speakers.json --language_id en 
+```
+
+Or using server.py directly, with language set to spanish and optional --device argument to set specific cuda device:
+```
+python C:\absolute\path\to\server.py --device cuda:0 --model_path C:\directory_path\to\model\directory --config_path C:\file_path\to\model\config.json --speakers_file_path C:\file_path\to\model\speakers.json --language_id es
+```
+
 ## Parameters
 
 The `/api/tts` endpoint accepts the following parameters:
@@ -43,3 +53,13 @@ The `/api/tts` endpoint accepts the following parameters:
 - `language-id`: Language ID (for multilingual models)
 - `speaker-wav`: Reference speaker audio file path (for models with voice cloning support)
 - `style-wav`: Style audio file path (for supported models)
+
+There is also a basic openai-compatible server endpoint at `/v1/audio/speech` which accepts the parameters in the basic OpenAI speech spec ( https://platform.openai.com/docs/api-reference/audio )
+
+- `model`: A string representing the model name (this is optional and ignored because the model is loaded with the server startup)
+- `input`: Input text (required)
+- `voice`: Can be one of the following: a string representing a Speaker ID in a multi-speaker TTS model, e.g., "Craig Gutsy" for XTTS2, a reference speaker audio file path (for models with voice cloning support) or a reference speaker directory path to a directory containing multiple audio files for that speaker (for models with voice cloning support)
+- `speed`: Optional, float value between 0.25-4.0 (default 1.0)
+- `response_format`: Optional, expected format of audio for response (defaults to mp3) (Options: "wav", "mp3", "opus", "aac", "flac", "pcm")
+
+When using the openai-compatible server endpoint, you should specify the language (if other than English) when running the server with the command line argument --language_id `langauge_code` for multilingual models

--- a/docs/source/server.md
+++ b/docs/source/server.md
@@ -22,9 +22,15 @@ http://localhost:5002) and synthesize speech.
 tts-server --model_name "<type>/<language>/<dataset>/<model_name>"
 ```
 
-It is also possible to set a default speaker for multi-speaker models:
+It is also possible to set a default speaker for multi-speaker models, so you
+don't have to add it in every request (although you can overwrite it):
 ```bash
 tts-server --model_name tts_models/en/vctk/vits --speaker_idx p376
+```
+
+And a default language ID for multilingual models (defaults to `en` for English):
+```bash
+tts-server --model_name tts_models/multilingual/multi-dataset/xtts_v2 --language_idx es
 ```
 
 Run a TTS and a vocoder model from the released model list. Note that not every vocoder is compatible with every TTS model.
@@ -34,32 +40,36 @@ tts-server --model_name "<type>/<language>/<dataset>/<model_name>" \
            --vocoder_name "<type>/<language>/<dataset>/<model_name>"
 ```
 
-Run a TTS model saved locally using GPU (cuda), supplying a language code for the model (default "en" for English):
-```bash
-tts-server --use_cuda --model_path C:\directory_path\to\model\directory --config_path C:\file_path\to\model\config.json --speakers_file_path C:\file_path\to\model\speakers.json --language_id en 
-```
-
-Or using server.py directly, with language set to spanish and optional --device argument to set specific cuda device:
-```
-python C:\absolute\path\to\server.py --device cuda:0 --model_path C:\directory_path\to\model\directory --config_path C:\file_path\to\model\config.json --speakers_file_path C:\file_path\to\model\speakers.json --language_id es
-```
-
 ## Parameters
+
+### Default endpoint
 
 The `/api/tts` endpoint accepts the following parameters:
 
-- `text`: Input text (required)
-- `speaker-id`: Speaker ID (for multi-speaker models)
-- `language-id`: Language ID (for multilingual models)
-- `speaker-wav`: Reference speaker audio file path (for models with voice cloning support)
-- `style-wav`: Style audio file path (for supported models)
+- `text`: Input text (required).
+- `speaker-id`: Speaker ID (for multi-speaker models).
+- `language-id`: Language ID (for multilingual models).
+- `speaker-wav`: Reference speaker audio file path (for models with voice cloning support).
+- `style-wav`: Style audio file path (for supported models).
 
-There is also a basic openai-compatible server endpoint at `/v1/audio/speech` which accepts the parameters in the basic OpenAI speech spec ( https://platform.openai.com/docs/api-reference/audio )
+### OpenAI-compatible endpoint
 
-- `model`: A string representing the model name (this is optional and ignored because the model is loaded with the server startup)
-- `input`: Input text (required)
-- `voice`: Can be one of the following: a string representing a Speaker ID in a multi-speaker TTS model, e.g., "Craig Gutsy" for XTTS2, a reference speaker audio file path (for models with voice cloning support) or a reference speaker directory path to a directory containing multiple audio files for that speaker (for models with voice cloning support)
-- `speed`: Optional, float value between 0.25-4.0 (default 1.0)
-- `response_format`: Optional, expected format of audio for response (defaults to mp3) (Options: "wav", "mp3", "opus", "aac", "flac", "pcm")
+There is also a basic
+[OpenAI-compatible](https://platform.openai.com/docs/api-reference/audio) server
+endpoint at `/v1/audio/speech`, which accepts these parameters:
 
-When using the openai-compatible server endpoint, you should specify the language (if other than English) when running the server with the command line argument --language_id `langauge_code` for multilingual models
+- `model`: A string representing the model name (this is optional and ignored
+  because the model is loaded with the server startup).
+- `input`: Input text (required).
+- `voice`: Can be one of the following: a string representing a Speaker ID in a
+  multi-speaker TTS model, e.g., "Craig Gutsy" for XTTS2, a reference speaker
+  audio file path (for models with voice cloning support) or a reference
+  speaker directory path to a directory containing multiple audio files for
+  that speaker (for models with voice cloning support).
+- `speed`: Optional, float (defaults to `1.0`).
+- `response_format`: Optional, expected format of audio for response (defaults
+  to `mp3`). Options: `wav`, `mp3`, `opus`, `aac`, `flac`, `pcm`.
+
+When using the OpenAI-compatible endpoint, you should specify the language (if
+other than English) when running the server with the command line argument
+`--language_idx <language_code>` for multilingual models.


### PR DESCRIPTION
-Add openai-compatible v1/audio/speech endpoint to server.py

-Add lowvram command line argument to server.py (if running in cuda, switches model to cpu when idle)

-Allow openai server to use built in speaker voices, cloning wavs or directory with wavs as the voice

-Allow language_id as server.py command line argument in alternative to request parameter

-split long input text using built in segmenter (eg to get around hard input limits in xtts2)

-tested on windows only (I do not have mac or linux)

-tested with xtts2 but changes in theory should not impact other models