### PR TITLE
Updating tts text cleaners, differating the question mark from the semicolon for Greek speakers.

### DIFF
--- a/TTS/tts/utils/text/cleaners.py
+++ b/TTS/tts/utils/text/cleaners.py
@@ -64,7 +64,8 @@ def replace_symbols(text: str, lang: str | None = "en") -> str:
         Output:
             text: "si lavi cau, diguemho"
     """
-    text = text.replace(";", ",")
+    if lang != "el":
+        text = text.replace(";", ",")
     text = text.replace("-", " ") if lang != "ca" else text.replace("-", "")
     text = text.replace(":", ",")
     if lang == "en":
@@ -79,7 +80,7 @@ def replace_symbols(text: str, lang: str | None = "en") -> str:
     return text
 
 
-def basic_cleaners(text: str) -> str:
+def basic_cleaners(text: str , lang: str = None) -> str:
     """Basic pipeline that lowercases and collapses whitespace without transliteration."""
     text = normalize_unicode(text)
     text = lowercase(text)
@@ -87,7 +88,7 @@ def basic_cleaners(text: str) -> str:
     return text
 
 
-def transliteration_cleaners(text: str) -> str:
+def transliteration_cleaners(text: str, lang: str = None) -> str:
     """Pipeline for non-English text that transliterates to ASCII."""
     text = normalize_unicode(text)
     # text = convert_to_ascii(text)
@@ -96,7 +97,7 @@ def transliteration_cleaners(text: str) -> str:
     return text
 
 
-def basic_german_cleaners(text: str) -> str:
+def basic_german_cleaners(text: str, lang: str = None) -> str:
     """Pipeline for German text"""
     text = normalize_unicode(text)
     text = lowercase(text)
@@ -105,7 +106,7 @@ def basic_german_cleaners(text: str) -> str:
 
 
 # TODO: elaborate it
-def basic_turkish_cleaners(text: str) -> str:
+def basic_turkish_cleaners(text: str, lang: str = None) -> str:
     """Pipeline for Turkish text"""
     text = normalize_unicode(text)
     text = text.replace("I", "ı")
@@ -114,7 +115,7 @@ def basic_turkish_cleaners(text: str) -> str:
     return text
 
 
-def english_cleaners(text: str) -> str:
+def english_cleaners(text: str, lang: str = None) -> str:
     """Pipeline for English text, including number and abbreviation expansion."""
     text = normalize_unicode(text)
     # text = convert_to_ascii(text)
@@ -122,13 +123,13 @@ def english_cleaners(text: str) -> str:
     text = expand_time_english(text)
     text = en_normalize_numbers(text)
     text = expand_abbreviations(text)
-    text = replace_symbols(text)
+    text = replace_symbols(text, lang="en")
     text = remove_aux_symbols(text)
     text = collapse_whitespace(text)
     return text
 
 
-def phoneme_cleaners(text: str) -> str:
+def phoneme_cleaners(text: str, lang: str = None) -> str:
     """Pipeline for phonemes mode, including number and abbreviation expansion.
 
     NB: This cleaner converts numbers into English words, for other languages
@@ -137,22 +138,22 @@ def phoneme_cleaners(text: str) -> str:
     text = normalize_unicode(text)
     text = en_normalize_numbers(text)
     text = expand_abbreviations(text)
-    text = replace_symbols(text)
+    text = replace_symbols(text, lang=lang)
     text = remove_aux_symbols(text)
     text = collapse_whitespace(text)
     return text
 
 
-def multilingual_phoneme_cleaners(text: str) -> str:
+def multilingual_phoneme_cleaners(text: str, lang: str = None) -> str:
     """Pipeline for phonemes mode, including number and abbreviation expansion."""
     text = normalize_unicode(text)
-    text = replace_symbols(text, lang=None)
+    text = replace_symbols(text, lang=lang)
     text = remove_aux_symbols(text)
     text = collapse_whitespace(text)
     return text
 
 
-def french_cleaners(text: str) -> str:
+def french_cleaners(text: str, lang: str = None) -> str:
     """Pipeline for French text. There is no need to expand numbers, phonemizer already does that"""
     text = normalize_unicode(text)
     text = expand_abbreviations(text, lang="fr")
@@ -163,7 +164,7 @@ def french_cleaners(text: str) -> str:
     return text
 
 
-def portuguese_cleaners(text: str) -> str:
+def portuguese_cleaners(text: str, lang: str = None) -> str:
     """Basic pipeline for Portuguese text. There is no need to expand abbreviation and
     numbers, phonemizer already does that"""
     text = normalize_unicode(text)
@@ -174,30 +175,30 @@ def portuguese_cleaners(text: str) -> str:
     return text
 
 
-def chinese_mandarin_cleaners(text: str) -> str:
+def chinese_mandarin_cleaners(text: str, lang: str = None) -> str:
     """Basic pipeline for chinese"""
     text = normalize_unicode(text)
     text = replace_numbers_to_characters_in_text(text)
     return text
 
 
-def multilingual_cleaners(text: str) -> str:
+def multilingual_cleaners(text: str, lang: str = None) -> str:
     """Pipeline for multilingual text"""
     text = normalize_unicode(text)
     text = lowercase(text)
-    text = replace_symbols(text, lang=None)
+    text = replace_symbols(text, lang=lang)
     text = remove_aux_symbols(text)
     text = collapse_whitespace(text)
     return text
 
 
-def no_cleaners(text: str) -> str:
+def no_cleaners(text: str, lang: str = None) -> str:
     # remove newline characters
     text = text.replace("\n", "")
     return text
 
 
-def normalize_unicode(text: str) -> str:
+def normalize_unicode(text: str, lang: str = None) -> str:
     """Normalize Unicode characters."""
     text = normalize("NFC", text)
     return text

--- a/TTS/tts/utils/text/tokenizer.py
+++ b/TTS/tts/utils/text/tokenizer.py
@@ -110,7 +110,7 @@ class TTSTokenizer:
         # TODO: text cleaner should pick the right routine based on the language
         logger.debug("Tokenizer input text: %s", text)
         if self.text_cleaner is not None:
-            text = self.text_cleaner(text)
+            text = self.text_cleaner(text, lang=language)
             logger.debug("Cleaned text: %s", text)
         if self.use_phonemes:
             text = self.phonemizer.phonemize(text, separator="", language=language)


### PR DESCRIPTION
Fix the bug where the Greek question mark in text is treated as a semicolon for Greek speakers.

To do this, the cleaners have to be aware of the speaker language when called.
