### PR TITLE
Replace jieba with spacy_pkuseg

### DIFF
--- a/TTS/tts/utils/text/chinese_mandarin/phonemizer.py
+++ b/TTS/tts/utils/text/chinese_mandarin/phonemizer.py
@@ -1,10 +1,20 @@
 try:
-    import jieba
     import pypinyin
+    import spacy_pkuseg as pkuseg
 except ImportError as e:
-    raise ImportError("Chinese requires: jieba, pypinyin") from e
+    raise ImportError("Chinese requires: spacy_pkuseg, pypinyin") from e
 
 from .pinyinToPhonemes import PINYIN_DICT
+
+_seg = None
+
+
+def _get_segmenter():
+    """Lazy initialization of pkuseg segmenter."""
+    global _seg
+    if _seg is None:
+        _seg = pkuseg.pkuseg()
+    return _seg
 
 
 def _chinese_character_to_pinyin(text: str) -> list[str]:
@@ -21,7 +31,8 @@ def _chinese_pinyin_to_phoneme(pinyin: str) -> str:
 
 
 def chinese_text_to_phonemes(text: str, seperator: str = "|") -> str:
-    tokenized_text = jieba.cut(text, HMM=False)
+    seg = _get_segmenter()
+    tokenized_text = seg.cut(text)
     tokenized_text = " ".join(tokenized_text)
     pinyined_text: list[str] = _chinese_character_to_pinyin(tokenized_text)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ ja = [
 ]
 # Chinese
 zh = [
-    "jieba>=0.42.1",
+    "spacy_pkuseg>=1.0.1",
     "pypinyin>=0.40.0",
 ]
 # All language-specific dependencies

--- a/tests/text_tests/test_phonemizer.py
+++ b/tests/text_tests/test_phonemizer.py
@@ -221,11 +221,15 @@ class TestJA_JPPhonemizer(unittest.TestCase):
 class TestZH_CN_Phonemizer(unittest.TestCase):
     def setUp(self):
         self.phonemizer = ZH_CN_Phonemizer()
-        self._TEST_CASES = ""
+        self._TEST_CASES = [
+            ("我来到北京清华大学", "w|o|3| |l|a|i|2|d|a|ʌ|4| |b|ɛ|i|3|d|ʑ|ɨ|ŋ|1| |t|ɕ|ɨ|ŋ|1|x|u|a|2| |d|a|4|ɕ|y|e|2"),
+            ("乒乓球拍卖完了", "p|ɨ|ŋ|1|p|ɑ|ŋ|1|t|ɕ|i|o|2| |p|a|i|1|m|a|i|4| |w|a|n|2|l|ø|5"),
+            ("中国科学技术大学", "d|ʒ|o|ŋ|1|ɡ|u|o|2| |k|ø|1|ɕ|y|e|2| |d|ʑ|i|4|ʂ|u|4| |d|a|4|ɕ|y|e|2"),
+        ]
 
     def test_phonemize(self):
-        # TODO: implement ZH phonemizer tests
-        pass
+        for text, phone in self._TEST_CASES:
+            self.assertEqual(self.phonemizer.phonemize(text, separator="|"), phone)
 
     def test_name(self):
         self.assertEqual(self.phonemizer.name(), "zh_cn_phonemizer")


### PR DESCRIPTION
Replacing jieba with [spacy-pkuseg](https://github.com/explosion/spacy-pkuseg)

Mainly to reduce warning messages as jieba does not seem to be maintained.

I don't know Chinese so others may need to do more informed testing.

Their comparisons: https://github.com/explosion/spacy-pkuseg/blob/master/readme/comparison.md


test_phonemizer.py::TestZH_CN_Phonemizer::test_get_supported_languages PASSED
tests/text_tests/test_phonemizer.py::TestZH_CN_Phonemizer::test_get_version PASSED
tests/text_tests/test_phonemizer.py::TestZH_CN_Phonemizer::test_is_available PASSED 
tests/text_tests/test_phonemizer.py::TestZH_CN_Phonemizer::test_name PASSED
tests/text_tests/test_phonemizer.py::TestZH_CN_Phonemizer::test_phonemize PASSED   