### PR TITLE
Handle romanization for Fairseq models

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
 
 ## 📣 News
 - **Fork of the [original, unmaintained repository](https://github.com/coqui-ai/TTS). New PyPI package: [coqui-tts](https://pypi.org/project/coqui-tts)**
-- 0.25.0: [OpenVoice](https://github.com/myshell-ai/OpenVoice) models now available for voice conversion.
+- 0.27.0: [Caching mechanism](https://coqui-tts.readthedocs.io/en/latest/cloning.html) for cloned voices.
+- 0.25.2: [OpenVoice](https://github.com/myshell-ai/OpenVoice) and [kNN-VC](https://github.com/bshall/knn-vc) models now available for voice conversion.
 - 0.24.2: Prebuilt wheels are now also published for macOS and Windows (in addition to Linux as before) for easier installation across platforms.
 - 0.20.0: XTTSv2 is here with 17 languages and better performance across the board. XTTS can stream with <200ms latency.
 - 0.19.0: XTTS fine-tuning code is out. Check the [example recipes](https://github.com/idiap/coqui-ai-TTS/tree/dev/recipes/ljspeech).
@@ -286,6 +287,9 @@ api.tts_to_file(
     file_path="output.wav"
 )
 ```
+
+**Note:** Some Fairseq models need the romanization library `uroman` to be
+installed. For this you can install `coqui-tts` with the `languages` extra.
 
 ### Command-line interface `tts`
 

--- a/TTS/tts/layers/xtts/tokenizer.py
+++ b/TTS/tts/layers/xtts/tokenizer.py
@@ -5,6 +5,7 @@ import textwrap
 from functools import cached_property
 
 import torch
+from ko_speech_tools import hangul_romanize
 from num2words import num2words
 from tokenizers import Tokenizer
 
@@ -596,16 +597,6 @@ def japanese_cleaners(text, katsu):
     return text
 
 
-def korean_transliterate(text):
-    try:
-        from hangul_romanize import Transliter
-        from hangul_romanize.rule import academic
-    except ImportError as e:
-        raise ImportError("Korean requires: hangul_romanize") from e
-    r = Transliter(academic)
-    return r.translit(text)
-
-
 DEFAULT_VOCAB_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../data/tokenizer.json")
 
 
@@ -657,7 +648,7 @@ class VoiceBpeTokenizer:
             if lang == "zh":
                 txt = chinese_transliterate(txt)
             if lang == "ko":
-                txt = korean_transliterate(txt)
+                txt = hangul_romanize(txt)
         elif lang == "ja":
             txt = japanese_cleaners(txt, self.katsu)
         else:

--- a/TTS/tts/models/vits.py
+++ b/TTS/tts/models/vits.py
@@ -1488,7 +1488,7 @@ class Vits(BaseTTS):
         """
         import json
 
-        from TTS.tts.utils.text.cleaners import basic_cleaners
+        from TTS.tts.utils.text.cleaners import basic_cleaners, uroman_cleaners
 
         self.disc = None
         # set paths
@@ -1503,13 +1503,13 @@ class Vits(BaseTTS):
             # Load the JSON data as a dictionary
             config_org = json.load(f)
         self.config.audio.sample_rate = config_org["data"]["sampling_rate"]
-        # self.config.add_blank = config['add_blank']
+        is_uroman = config_org["data"]["training_files"].endswith("uroman")
         # set tokenizer
         vocab = FairseqVocab(vocab_file)
         self.text_encoder.emb = nn.Embedding(vocab.num_chars, config.model_args.hidden_channels)
         self.tokenizer = TTSTokenizer(
             use_phonemes=False,
-            text_cleaner=basic_cleaners,
+            text_cleaner=uroman_cleaners if is_uroman else basic_cleaners,
             characters=vocab,
             phonemizer=None,
             add_blank=config_org["data"]["add_blank"],

--- a/TTS/tts/utils/text/cleaners.py
+++ b/TTS/tts/utils/text/cleaners.py
@@ -1,4 +1,8 @@
-"""Set of default text cleaners"""
+"""Set of default text cleaners.
+
+Original cleaners from (MIT license):
+https://github.com/keithito/tacotron/blob/master/text/cleaners.py
+"""
 
 import re
 from unicodedata import normalize

--- a/TTS/tts/utils/text/cleaners.py
+++ b/TTS/tts/utils/text/cleaners.py
@@ -15,6 +15,8 @@ from .french.abbreviations import abbreviations_fr
 # Regular expression matching whitespace:
 _whitespace_re = re.compile(r"\s+")
 
+_uroman = None
+
 
 def expand_abbreviations(text: str, lang: str = "en") -> str:
     if lang == "en":
@@ -39,6 +41,19 @@ def collapse_whitespace(text: str) -> str:
 
 def convert_to_ascii(text: str) -> str:
     return anyascii(text)
+
+
+def romanize(text: str, language: str | None = None) -> str:
+    """Romanize any unicode input with uroman."""
+    global _uroman
+    if _uroman is None:
+        try:
+            import uroman
+        except ImportError as e:
+            msg = "Package not installed: uroman (available in the `languages` extra)"
+            raise ImportError(msg) from e
+        _uroman = uroman.Uroman()
+    return _uroman.romanize_string(text, lcode=language)
 
 
 def remove_aux_symbols(text: str) -> str:
@@ -91,6 +106,15 @@ def transliteration_cleaners(text: str) -> str:
     """Pipeline for non-English text that transliterates to ASCII."""
     text = normalize_unicode(text)
     # text = convert_to_ascii(text)
+    text = lowercase(text)
+    text = collapse_whitespace(text)
+    return text
+
+
+def uroman_cleaners(text: str) -> str:
+    """Pipeline for romanizing non-Latin text with uroman used by some Fairseq models."""
+    text = normalize_unicode(text)
+    text = romanize(text)
     text = lowercase(text)
     text = collapse_whitespace(text)
     return text

--- a/TTS/tts/utils/text/korean/phonemizer.py
+++ b/TTS/tts/utils/text/korean/phonemizer.py
@@ -1,7 +1,4 @@
-try:
-    from jamo import hangul_to_jamo
-except ImportError as e:
-    raise ImportError("Korean requires: g2pkk, jamo") from e
+import ko_speech_tools as kst
 
 from TTS.tts.utils.text.korean.korean import normalize
 
@@ -21,19 +18,18 @@ def korean_text_to_phonemes(text, character: str = "hangeul") -> str:
     """
     global g2p  # pylint: disable=global-statement
     if g2p is None:
-        from g2pkk import G2p
-
-        g2p = G2p()
-
-    if character == "english":
-        from anyascii import anyascii
-
-        text = normalize(text)
-        text = g2p(text)
-        text = anyascii(text)
-        return text
+        try:
+            g2p = kst.G2p()
+        except ImportError as e:
+            raise ImportError("Korean requires: mecab-ko (available in the `ko` extra)") from e
 
     text = normalize(text)
     text = g2p(text)
-    text = list(hangul_to_jamo(text))  # '하늘' --> ['ᄒ', 'ᅡ', 'ᄂ', 'ᅳ', 'ᆯ']
+
+    if character == "english":
+        # Not used in practice, just allows easier debugging
+        from anyascii import anyascii
+
+        return anyascii(text)
+    text = list(kst.jamo.hangul_to_jamo(text))  # '하늘' --> ['ᄒ', 'ᅡ', 'ᄂ', 'ᅳ', 'ᆯ']
     return "".join(text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dependencies = [
     "coqui-tts-trainer>=0.3.0,<0.4.0",
     "coqpit-config>=0.2.0,<0.3.0",
     "monotonic-alignment-search>=0.1.0",
+    "ko-speech-tools>=0.1.0",
     # Gruut + supported languages
     "gruut[de,es,fr]>=2.4.0",
     # Tortoise
@@ -109,10 +110,7 @@ bn = [
 ]
 # Korean
 ko = [
-    "hangul_romanize>=0.1.0",
-    "jamo>=0.4.1",
-    "g2pkk>=0.1.1",
-    "pip>=22.2",
+    "ko-speech-tools[g2p]>=0.1.0",
 ]
 # Japanese
 ja = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ zh = [
 # All language-specific dependencies
 languages = [
     "coqui-tts[bn,ja,ko,zh]",
+    "uroman>=1.3.1.1",
 ]
 # Installs all extras (except dev and docs)
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ classifiers = [
 dependencies = [
     # Core
     "numpy>=1.26.0",
-    "cython>=3.0.0",
     "scipy>=1.13.0",
     "torch>=2.1,<2.9",
     "torchaudio>=2.1.0,<2.9",

--- a/tests/text_tests/test_korean_phonemizer.py
+++ b/tests/text_tests/test_korean_phonemizer.py
@@ -1,7 +1,4 @@
-import sys
 import unittest
-
-import pytest
 
 from TTS.tts.utils.text.korean.phonemizer import korean_text_to_phonemes
 
@@ -20,7 +17,6 @@ _TEST_CASES_EN = """
 """
 
 
-@pytest.mark.skipif(not sys.version_info < (3, 13), reason="Requires Python 3.12 or lower")
 class TestText(unittest.TestCase):
     def test_korean_text_to_phonemes(self):
         for line in _TEST_CASES.strip().split("\n"):
@@ -29,7 +25,3 @@ class TestText(unittest.TestCase):
         for line in _TEST_CASES_EN.strip().split("\n"):
             text, phone = line.split("/")
             self.assertEqual(korean_text_to_phonemes(text, character="english"), phone)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/text_tests/test_text_cleaners.py
+++ b/tests/text_tests/test_text_cleaners.py
@@ -1,10 +1,11 @@
-#!/usr/bin/env python3
+import pytest
 
 from TTS.tts.utils.text.cleaners import (
     english_cleaners,
     multilingual_phoneme_cleaners,
     normalize_unicode,
     phoneme_cleaners,
+    romanize,
 )
 
 
@@ -53,3 +54,15 @@ def test_normalize_unicode() -> None:
     ]
     for arg, expect in test_cases:
         assert normalize_unicode(arg) == expect
+
+
+@pytest.mark.parametrize(
+    ("text", "language", "expected"),
+    [
+        ("Игорь Стравинский", None, "Igor Stravinsky"),
+        ("Игорь Стравинский", "ukr", "Yhor Stravynsky"),
+        ("안녕하세요.", None, "annyeonghaseyo."),
+    ],
+)
+def test_romanize(text, language, expected) -> None:
+    assert romanize(text, language) == expected


### PR DESCRIPTION
Some Fairseq models require the input text to be romanized with `uroman`. This PR adds a text cleaner that will be used for this where needed (`uroman` can be installed via the `languages` extra). Fixes #472.

Also replace the various Korean-specific dependencies that are mostly unmaintained with one new streamlined package: https://pypi.org/project/ko-speech-tools