### PR TITLE
Refactor attention-derived duration computation

### DIFF
--- a/TTS/tts/models/base_tts.py
+++ b/TTS/tts/models/base_tts.py
@@ -19,6 +19,7 @@ from TTS.tts.datasets.dataset import TTSDataset
 from TTS.tts.utils.data import get_length_balancer_weights
 from TTS.tts.utils.languages import LanguageManager, get_language_balancer_weights
 from TTS.tts.utils.speakers import SpeakerManager, get_speaker_balancer_weights
+from TTS.tts.utils.durations import durations_from_alignment
 from TTS.tts.utils.synthesis import inv_spectrogram
 from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
 from TTS.utils.generic_utils import warn_synthesize_config_deprecated, warn_synthesize_speaker_id_deprecated
@@ -178,25 +179,7 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
         max_spec_length = torch.max(mel_lengths.float())
 
         # compute durations from attention masks
-        durations = None
-        if attn_mask is not None:
-            durations = torch.zeros(attn_mask.shape[0], attn_mask.shape[2])
-            for idx, am in enumerate(attn_mask):
-                # compute raw durations
-                c_idxs = am[:, : text_lengths[idx], : mel_lengths[idx]].max(1)[1]
-                # c_idxs, counts = torch.unique_consecutive(c_idxs, return_counts=True)
-                c_idxs, counts = torch.unique(c_idxs, return_counts=True)
-                dur = torch.ones([text_lengths[idx]]).to(counts.dtype)
-                dur[c_idxs] = counts
-                # smooth the durations and set any 0 duration to 1
-                # by cutting off from the largest duration indeces.
-                extra_frames = dur.sum() - mel_lengths[idx]
-                largest_idxs = torch.argsort(-dur)[:extra_frames]
-                dur[largest_idxs] -= 1
-                assert dur.sum() == mel_lengths[idx], (
-                    f" [!] total duration {dur.sum()} vs spectrogram length {mel_lengths[idx]}"
-                )
-                durations[idx, : text_lengths[idx]] = dur
+        durations = durations_from_alignment(attn_mask, text_lengths, mel_lengths)
 
         # set stop targets wrt reduction factor
         stop_targets = stop_targets.view(text_input.shape[0], stop_targets.size(1) // self.config.r, -1)

--- a/TTS/tts/utils/durations.py
+++ b/TTS/tts/utils/durations.py
@@ -1,0 +1,143 @@
+"""Utilities for working with token durations derived from attention maps."""
+
+from __future__ import annotations
+
+from math import ceil
+from typing import Iterable
+
+import torch
+
+
+def _ensure_3d_attention(attn_mask: torch.Tensor) -> torch.Tensor:
+    """Collapse a batched attention map to ``[B, T_text, T_mel]``.
+
+    The dataset collate function pads the attention masks to a 4-D tensor of
+    shape ``[B, 1, T_text, T_mel]``. Some models may also return multi-head
+    attention tensors. In both cases we pick the strongest head per frame by
+    taking the maximum over the head dimension.
+    """
+
+    if attn_mask.dim() == 3:
+        return attn_mask
+
+    if attn_mask.dim() == 4:
+        # Collapse the head dimension. If there is only a single head this is
+        # equivalent to ``squeeze`` but keeps the code path uniform.
+        attn_mask = attn_mask.max(dim=1).values
+        return attn_mask
+
+    raise ValueError(
+        "Expected attention mask with 3 or 4 dimensions, "
+        f"got shape {tuple(attn_mask.shape)}"
+    )
+
+
+def _repeat_indices(indices: torch.Tensor, total: int) -> torch.Tensor:
+    """Repeat ``indices`` until reaching ``total`` elements and crop the result."""
+
+    if indices.numel() == 0 or total <= 0:
+        return indices.new_empty(0)
+
+    repeats = ceil(total / indices.numel())
+    return indices.repeat(repeats)[:total]
+
+
+def durations_from_alignment(
+    attn_mask: torch.Tensor | None,
+    text_lengths: torch.Tensor | Iterable[int],
+    mel_lengths: torch.Tensor | Iterable[int],
+) -> torch.Tensor | None:
+    """Compute token durations from a padded attention alignment map.
+
+    Parameters
+    ----------
+    attn_mask:
+        Attention tensor with shape ``[B, T_text, T_mel]`` or ``[B, 1, T_text, T_mel]``.
+        When ``None`` no durations are computed and ``None`` is returned.
+    text_lengths:
+        Sequence of text lengths for the batch.
+    mel_lengths:
+        Sequence of mel-frame lengths for the batch.
+
+    Returns
+    -------
+    torch.Tensor | None
+        Tensor with shape ``[B, max(text_lengths)]`` that stores the duration of
+        each token. The tensor uses the same ``dtype`` and ``device`` as the
+        attention mask.
+    """
+
+    if attn_mask is None:
+        return None
+
+    attn_mask = _ensure_3d_attention(attn_mask)
+    batch, max_text_len, _ = attn_mask.shape
+    device = attn_mask.device
+    dtype = attn_mask.dtype
+
+    # Convert inputs to tensors for indexing while supporting lists/tuples.
+    if not torch.is_tensor(text_lengths):
+        text_lengths = torch.as_tensor(text_lengths, device=device)
+    if not torch.is_tensor(mel_lengths):
+        mel_lengths = torch.as_tensor(mel_lengths, device=device)
+
+    durations = torch.zeros(batch, max_text_len, device=device, dtype=dtype)
+
+    for idx in range(batch):
+        text_len = int(text_lengths[idx])
+        mel_len = int(mel_lengths[idx])
+
+        if text_len <= 0 or mel_len <= 0:
+            continue
+
+        attn = attn_mask[idx, :text_len, :mel_len]
+
+        # Count how many frames attend to each token.
+        frame_to_token = attn.max(dim=0).indices
+        dur = torch.bincount(frame_to_token, minlength=text_len)
+        dur = dur.to(dtype)
+
+        # Guarantee that every token has at least one frame by assigning a
+        # single frame to zero-duration tokens and compensating elsewhere.
+        zero_tokens = dur == 0
+        if zero_tokens.any():
+            dur = dur + zero_tokens.to(dtype)
+
+        diff = int(dur.sum().item() - mel_len)
+        if diff != 0:
+            if diff > 0:
+                candidates = torch.nonzero(dur > 1, as_tuple=False).view(-1)
+                if candidates.numel() == 0:
+                    candidates = torch.arange(text_len, device=device)
+                adjust_idx = _repeat_indices(
+                    candidates[torch.argsort(dur[candidates], descending=True)],
+                    diff,
+                )
+                if adjust_idx.numel() > 0:
+                    adjustment = torch.zeros_like(dur)
+                    adjustment.scatter_add_(
+                        0,
+                        adjust_idx,
+                        torch.ones(adjust_idx.numel(), device=device, dtype=dtype),
+                    )
+                    dur = dur - adjustment
+            else:
+                diff = -diff
+                candidates = torch.arange(text_len, device=device)
+                adjust_idx = _repeat_indices(
+                    candidates[torch.argsort(dur[candidates], descending=True)],
+                    diff,
+                )
+                if adjust_idx.numel() > 0:
+                    adjustment = torch.zeros_like(dur)
+                    adjustment.scatter_add_(
+                        0,
+                        adjust_idx,
+                        torch.ones(adjust_idx.numel(), device=device, dtype=dtype),
+                    )
+                    dur = dur + adjustment
+
+        durations[idx, :text_len] = dur
+
+    return durations
+

--- a/TTS/vc/models/base_vc.py
+++ b/TTS/vc/models/base_vc.py
@@ -17,6 +17,7 @@ from TTS.tts.datasets.dataset import TTSDataset
 from TTS.tts.utils.data import get_length_balancer_weights
 from TTS.tts.utils.languages import LanguageManager, get_language_balancer_weights
 from TTS.tts.utils.speakers import SpeakerManager, get_speaker_balancer_weights
+from TTS.tts.utils.durations import durations_from_alignment
 from TTS.utils.audio.processor import AudioProcessor
 
 # pylint: skip-file
@@ -180,25 +181,7 @@ class BaseVC(BaseTrainerModel):
         max_spec_length = torch.max(mel_lengths.float())
 
         # compute durations from attention masks
-        durations = None
-        if attn_mask is not None:
-            durations = torch.zeros(attn_mask.shape[0], attn_mask.shape[2])
-            for idx, am in enumerate(attn_mask):
-                # compute raw durations
-                c_idxs = am[:, : text_lengths[idx], : mel_lengths[idx]].max(1)[1]
-                # c_idxs, counts = torch.unique_consecutive(c_idxs, return_counts=True)
-                c_idxs, counts = torch.unique(c_idxs, return_counts=True)
-                dur = torch.ones([text_lengths[idx]]).to(counts.dtype)
-                dur[c_idxs] = counts
-                # smooth the durations and set any 0 duration to 1
-                # by cutting off from the largest duration indeces.
-                extra_frames = dur.sum() - mel_lengths[idx]
-                largest_idxs = torch.argsort(-dur)[:extra_frames]
-                dur[largest_idxs] -= 1
-                assert dur.sum() == mel_lengths[idx], (
-                    f" [!] total duration {dur.sum()} vs spectrogram length {mel_lengths[idx]}"
-                )
-                durations[idx, : text_lengths[idx]] = dur
+        durations = durations_from_alignment(attn_mask, text_lengths, mel_lengths)
 
         # set stop targets wrt reduction factor
         stop_targets = stop_targets.view(text_input.shape[0], stop_targets.size(1) // self.config.r, -1)


### PR DESCRIPTION
Readability and Cleanliness:
By replacing the manual implementation with a function call (**durations_from_alignment**), the **format_batch** function becomes much cleaner and easier to read. This makes it simpler for other developers to understand what’s happening.

Reusability:
The logic for calculating durations based on the attention mask is now encapsulated in a separate function. This means you can reuse durations_from_alignment in other parts of the codebase without duplicating logic.

Separation of Concerns:
The format_batch function should focus on formatting the batch, not on the internal details of duration calculation. By moving the logic out, each function has a clear responsibility.