### PR TITLE
docs(formatters): show expected metadata format, improve error handling

### DIFF
--- a/TTS/tts/datasets/formatters.py
+++ b/TTS/tts/datasets/formatters.py
@@ -44,8 +44,21 @@ def register_formatter(name: str, formatter: Formatter) -> None:
 
 
 def cml_tts(root_path, meta_file, ignored_speakers=None):
-    """Normalizes the CML-TTS meta data file to TTS format
-    https://github.com/freds0/CML-TTS-Dataset/"""
+    """Normalize the CML-TTS meta data file to TTS format.
+
+    Website: https://github.com/freds0/CML-TTS-Dataset/
+
+    Expected metadata format (pipe-delimited CSV with header)::
+
+        wav_filename|transcript|client_id|emotion_name
+        audio/speaker1/file001.wav|This is the transcript.|speaker1|neutral
+        audio/speaker2/file002.wav|Another sentence here.|speaker2|happy
+
+    Note: The ``client_id`` and ``emotion_name`` columns are optional. If missing,
+    defaults to ``"default"`` speaker and ``"neutral"`` emotion.
+
+    Audio files are located at: ``{root_path}/{wav_filename}``
+    """
     filepath = os.path.join(root_path, meta_file)
     # ensure there are 4 columns for every line
     with open(filepath, encoding="utf8") as f:
@@ -85,7 +98,19 @@ def cml_tts(root_path, meta_file, ignored_speakers=None):
 
 
 def coqui(root_path, meta_file, ignored_speakers=None):
-    """Interal dataset formatter."""
+    """Normalize the Coqui internal dataset format to TTS format.
+
+    Expected metadata format (pipe-delimited CSV with header)::
+
+        audio_file|text|speaker_name|emotion_name
+        clips/speaker1/file001.wav|This is the transcript.|speaker1|neutral
+        clips/speaker2/file002.wav|Another sentence here.|speaker2|happy
+
+    Note: The ``speaker_name`` and ``emotion_name`` columns are optional. If missing,
+    defaults to ``"coqui"`` speaker and ``"neutral"`` emotion.
+
+    Audio files are located at: ``{root_path}/{audio_file}``
+    """
     filepath = os.path.join(root_path, meta_file)
     # ensure there are 4 columns for every line
     with open(filepath, encoding="utf8") as f:
@@ -126,7 +151,17 @@ def coqui(root_path, meta_file, ignored_speakers=None):
 
 def tweb(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
     """Normalize TWEB dataset.
-    https://www.kaggle.com/bryanpark/the-world-english-bible-speech-dataset
+
+    Website: https://www.kaggle.com/bryanpark/the-world-english-bible-speech-dataset
+
+    Expected metadata format (tab-delimited)::
+
+        file001\tThis is the transcript.
+        file002\tAnother sentence here.
+
+    Note: ``.wav`` is automatically appended to the file ID.
+
+    Audio files should be in: ``{root_path}/{filename}.wav``
     """
     txt_file = os.path.join(root_path, meta_file)
     items = []
@@ -141,7 +176,17 @@ def tweb(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
 
 
 def mozilla(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
-    """Normalizes Mozilla meta data files to TTS format"""
+    """Normalize Mozilla meta data files to TTS format.
+
+    Expected metadata format (pipe-delimited)::
+
+        This is the transcript.|file001.wav
+        Another sentence here.|file002.wav
+
+    Note: Text comes before the filename in this format.
+
+    Audio files should be in: ``{root_path}/wavs/{filename}``
+    """
     txt_file = os.path.join(root_path, meta_file)
     items = []
     speaker_name = "mozilla"
@@ -156,7 +201,19 @@ def mozilla(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
 
 
 def mozilla_de(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
-    """Normalizes Mozilla meta data files to TTS format"""
+    """Normalize Mozilla German dataset meta data files to TTS format.
+
+    Expected metadata format (pipe-delimited, ISO 8859-1 encoding)::
+
+        1_0001.wav|This is the German transcript.
+        1_0002.wav|Another sentence here.
+        2_0001.wav|From a different batch.
+
+    Note: Files are organized in batch folders named ``BATCH_{N}_FINAL`` where N
+    is extracted from the filename prefix (e.g., ``1_0001.wav`` → ``BATCH_1_FINAL``).
+
+    Audio files should be in: ``{root_path}/BATCH_{N}_FINAL/{filename}``
+    """
     txt_file = os.path.join(root_path, meta_file)
     items = []
     speaker_name = "mozilla"
@@ -172,7 +229,20 @@ def mozilla_de(root_path, meta_file, **kwargs):  # pylint: disable=unused-argume
 
 
 def mailabs(root_path, meta_files=None, ignored_speakers=None):
-    """Normalizes M-AI-Labs meta data files to TTS format
+    """Normalize M-AI-Labs meta data files to TTS format.
+
+    Website: https://github.com/imdatceleste/m-ailabs-dataset
+
+    Expected metadata format (pipe-delimited)::
+
+        file001|This is the transcript.
+        file002|Another sentence here.
+
+    Note: This dataset automatically searches for all ``metadata.csv`` files recursively
+    in ``root_path`` unless ``meta_files`` is specified. Speaker names are extracted from
+    the folder structure: ``by_book/{gender}/{speaker_name}/...``
+
+    Audio files should be in: ``{folder}/wavs/{filename}.wav``
 
     Args:
         root_path (str): root folder of the MAILAB language folder.
@@ -223,8 +293,20 @@ def mailabs(root_path, meta_files=None, ignored_speakers=None):
 
 
 def ljspeech(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
-    """Normalizes the LJSpeech meta data file to TTS format
-    https://keithito.com/LJ-Speech-Dataset/"""
+    """Normalize the LJSpeech meta data file to TTS format.
+
+    Website: https://keithito.com/LJ-Speech-Dataset/
+
+    Expected metadata format (pipe-delimited)::
+
+        LJ001-0001|This is the transcription.|This is the normalized transcription.
+        LJ001-0002|It'll be $16 sir.|It'll be sixteen dollars sir.
+
+    Note: ``.wav`` is automatically appended to the utterance ID and only the text
+    of the third column is used.
+
+    Audio files should be in: ``{root_path}/wavs/{filename}.wav``
+    """
     txt_file = os.path.join(root_path, meta_file)
     items = []
     speaker_name = "ljspeech"
@@ -232,6 +314,9 @@ def ljspeech(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
         for line in ttf:
             cols = line.split("|")
             wav_file = os.path.join(root_path, "wavs", cols[0] + ".wav")
+            if len(cols) < 3:
+                msg = "LJSpeech format expects 3 pipe-delimited columns in the metadata file."
+                raise IndexError(msg)
             text = cols[2]
             items.append({"text": text, "audio_file": wav_file, "speaker_name": speaker_name, "root_path": root_path})
     return items
@@ -258,8 +343,19 @@ def ljspeech_test(root_path, meta_file, **kwargs):  # pylint: disable=unused-arg
 
 
 def thorsten(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
-    """Normalizes the thorsten meta data file to TTS format
-    https://github.com/thorstenMueller/deep-learning-german-tts/"""
+    """Normalize the Thorsten German TTS meta data file to TTS format.
+
+    Website: https://github.com/thorstenMueller/Thorsten-Voice
+
+    Expected metadata format (pipe-delimited)::
+
+        file001|This is the German transcript.
+        file002|Another sentence here.
+
+    Note: ``.wav`` is automatically appended to the file ID.
+
+    Audio files should be in: ``{root_path}/wavs/{filename}.wav``
+    """
     txt_file = os.path.join(root_path, meta_file)
     items = []
     speaker_name = "thorsten"
@@ -273,8 +369,21 @@ def thorsten(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
 
 
 def sam_accenture(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
-    """Normalizes the sam-accenture meta data file to TTS format
-    https://github.com/Sam-Accenture-Non-Binary-Voice/non-binary-voice-files"""
+    """Normalize the Sam Accenture Non-Binary Voice meta data file to TTS format.
+
+    Website: https://github.com/Sam-Accenture-Non-Binary-Voice/non-binary-voice-files
+
+    Expected metadata format (XML file, typically ``voice_over_recordings/recording_script.xml``)::
+
+        <recording>
+            <fileid id="file001">This is the transcript.</fileid>
+            <fileid id="file002">Another sentence here.</fileid>
+        </recording>
+
+    Note: ``.wav`` is automatically appended to the file ID.
+
+    Audio files should be in: ``{root_path}/vo_voice_quality_transformation/{id}.wav``
+    """
     xml_file = os.path.join(root_path, "voice_over_recordings", meta_file)
     xml_root = ET.parse(xml_file).getroot()
     items = []
@@ -290,8 +399,19 @@ def sam_accenture(root_path, meta_file, **kwargs):  # pylint: disable=unused-arg
 
 
 def ruslan(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
-    """Normalizes the RUSLAN meta data file to TTS format
-    https://ruslan-corpus.github.io/"""
+    """Normalize the RUSLAN meta data file to TTS format.
+
+    Website: https://ruslan-corpus.github.io/
+
+    Expected metadata format (pipe-delimited)::
+
+        file001|This is the Russian transcript.
+        file002|Another sentence here.
+
+    Note: ``.wav`` is automatically appended to the file ID.
+
+    Audio files should be in: ``{root_path}/RUSLAN/{filename}.wav``
+    """
     txt_file = os.path.join(root_path, meta_file)
     items = []
     speaker_name = "ruslan"
@@ -305,7 +425,19 @@ def ruslan(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
 
 
 def css10(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
-    """Normalizes the CSS10 dataset file to TTS format"""
+    """Normalize the CSS10 dataset file to TTS format.
+
+    Website: https://github.com/Kyubyong/css10
+
+    Expected metadata format (pipe-delimited)::
+
+        audio/file001.wav|This is the transcript.
+        audio/file002.wav|Another sentence here.
+
+    Note: The full audio file path (relative to ``root_path``) is included in the metadata.
+
+    Audio files are located at: ``{root_path}/{filepath}``
+    """
     txt_file = os.path.join(root_path, meta_file)
     items = []
     speaker_name = "css10"
@@ -319,7 +451,19 @@ def css10(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
 
 
 def nancy(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
-    """Normalizes the Nancy meta data file to TTS format"""
+    """Normalize the Nancy meta data file to TTS format.
+
+    Website: https://www.cstr.ed.ac.uk/projects/blizzard/2011/lessac_blizzard2011/
+
+    Expected metadata format (space-delimited with quoted text)::
+
+        ( file001 "This is the transcript." )
+        ( file002 "Another sentence here." )
+
+    Note: ``.wav`` is automatically appended to the file ID.
+
+    Audio files should be in: ``{root_path}/wavn/{filename}.wav``
+    """
     txt_file = os.path.join(root_path, meta_file)
     items = []
     speaker_name = "nancy"
@@ -333,7 +477,18 @@ def nancy(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
 
 
 def common_voice(root_path, meta_file, ignored_speakers=None):
-    """Normalize the common voice meta data file to TTS format."""
+    """Normalize the Mozilla Common Voice meta data file to TTS format.
+
+    Website: https://commonvoice.mozilla.org/en/datasets
+
+    Expected metadata format (tab-delimited with header)::
+
+        client_id	path	sentence	...
+        speaker001	file001.mp3	This is the transcript.	...
+        speaker002	file002.mp3	Another sentence here.	...
+
+    Audio files should be in: ``{root_path}/clips/{filename}.mp3``
+    """
     txt_file = os.path.join(root_path, meta_file)
     items = []
     with open(txt_file, encoding="utf-8") as ttf:
@@ -347,7 +502,7 @@ def common_voice(root_path, meta_file, ignored_speakers=None):
             if isinstance(ignored_speakers, list):
                 if speaker_name in ignored_speakers:
                     continue
-            wav_file = os.path.join(root_path, "clips", cols[1].replace(".mp3", ".wav"))
+            wav_file = os.path.join(root_path, "clips", cols[1])
             items.append(
                 {"text": text, "audio_file": wav_file, "speaker_name": "MCV_" + speaker_name, "root_path": root_path}
             )
@@ -355,7 +510,22 @@ def common_voice(root_path, meta_file, ignored_speakers=None):
 
 
 def libri_tts(root_path, meta_files=None, ignored_speakers=None):
-    """https://ai.google/tools/datasets/libri-tts/"""
+    """Normalize the LibriTTS meta data file to TTS format.
+
+    Website: https://www.openslr.org/60/
+
+    Expected metadata format (tab-delimited, no header)::
+
+        84_121550_000007_000000	It's $50 sir.	It's fifty dollars sir.
+        84_121550_000007_000000	Call me at 5pm.	Call me at five P M.
+
+    Note: This dataset automatically searches for all ``*trans.tsv`` files recursively
+    in ``root_path`` unless ``meta_files`` is specified. ``.wav`` is automatically appended.
+    Only the normalized transcript (third column) is used. The speaker name is
+    the first part of the utterance ID.
+
+    Audio files should be in: ``{root_path}/{speaker}/{chapter}/{filename}.wav``
+    """
     items = []
     if not meta_files:
         meta_files = glob(f"{root_path}/**/*trans.tsv", recursive=True)
@@ -391,6 +561,17 @@ def libri_tts(root_path, meta_files=None, ignored_speakers=None):
 
 
 def custom_turkish(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
+    """Normalize a custom Turkish dataset to TTS format.
+
+    Expected metadata format (pipe-delimited)::
+
+        file001|Bu bir transkript.
+        file002|Başka bir cümle.
+
+    Note: ``.wav`` is automatically appended to the file ID.
+
+    Audio files should be in: ``{root_path}/wavs/{filename}.wav``
+    """
     txt_file = os.path.join(root_path, meta_file)
     items = []
     speaker_name = "turkish-female"
@@ -408,9 +589,21 @@ def custom_turkish(root_path, meta_file, **kwargs):  # pylint: disable=unused-ar
     return items
 
 
-# ToDo: add the dataset link when the dataset is released publicly
 def brspeech(root_path, meta_file, ignored_speakers=None):
-    """BRSpeech 3.0 beta"""
+    """Normalize the BRSpeech 3.0 beta dataset to TTS format.
+
+    Website: https://github.com/freds0/BRSpeech-Dataset
+
+    Expected metadata format (pipe-delimited with header)::
+
+        wav_filename|transcript_raw|transcript|speaker_id
+        audio/speaker1/file001.wav|Raw text|Normalized text|speaker1
+        audio/speaker2/file002.wav|Raw text|Normalized text|speaker2
+
+    Note: Only the normalized transcript (third column) is used.
+
+    Audio files are located at: ``{root_path}/{wav_filename}``
+    """
     txt_file = os.path.join(root_path, meta_file)
     items = []
     with open(txt_file, encoding="utf-8") as ttf:
@@ -430,25 +623,24 @@ def brspeech(root_path, meta_file, ignored_speakers=None):
 
 
 def vctk(root_path, meta_files=None, wavs_path="wav48_silence_trimmed", mic="mic1", ignored_speakers=None):
-    """VCTK dataset v0.92.
+    """Normalize the VCTK dataset v0.92 to TTS format.
 
-    URL:
-        https://datashare.ed.ac.uk/bitstream/handle/10283/3443/VCTK-Corpus-0.92.zip
+    Website: https://datashare.ed.ac.uk/bitstream/handle/10283/3443/VCTK-Corpus-0.92.zip
 
-    This dataset has 2 recordings per speaker that are annotated with ```mic1``` and ```mic2```.
-    It is believed that (😄 ) ```mic1``` files are the same as the previous version of the dataset.
+    Expected metadata format (individual text files per utterance)::
 
-    mic1:
-        Audio recorded using an omni-directional microphone (DPA 4035).
-        Contains very low frequency noises.
-        This is the same audio released in previous versions of VCTK:
-        https://doi.org/10.7488/ds/1994
+        txt/p225/p225_001.txt: "Please call Stella."
+        txt/p225/p225_002.txt: "Ask her to bring these things with her from the store."
 
-    mic2:
-        Audio recorded using a small diaphragm condenser microphone with
-        very wide bandwidth (Sennheiser MKH 800).
-        Two speakers, p280 and p315 had technical issues of the audio
-        recordings using MKH 800.
+    Note: This dataset automatically searches for all ``.txt`` files in ``{root_path}/txt/``.
+    Each text file contains a single line of transcription. Audio files use ``.flac`` format.
+
+    This dataset has 2 recordings per speaker (``mic1`` and ``mic2``):
+
+    - **mic1**: Omni-directional microphone (DPA 4035). Same as previous VCTK versions.
+    - **mic2**: Small diaphragm condenser microphone (Sennheiser MKH 800). Speakers p280 and p315 have technical issues.
+
+    Audio files should be in: ``{root_path}/{wavs_path}/{speaker_id}/{file_id}_{mic}.flac``
     """
     file_ext = "flac"
     items = []
@@ -477,7 +669,20 @@ def vctk(root_path, meta_files=None, wavs_path="wav48_silence_trimmed", mic="mic
 
 
 def vctk_old(root_path, meta_files=None, wavs_path="wav48", ignored_speakers=None):
-    """homepages.inf.ed.ac.uk/jyamagis/release/VCTK-Corpus.tar.gz"""
+    """Normalize the older VCTK dataset to TTS format.
+
+    Website: https://datashare.ed.ac.uk/handle/10283/2651
+
+    Expected metadata format (individual text files per utterance)::
+
+        txt/p225/p225_001.txt: "Please call Stella."
+        txt/p225/p225_002.txt: "Ask her to bring these things with her from the store."
+
+    Note: This dataset automatically searches for all ``.txt`` files in ``{root_path}/txt/``.
+    Each text file contains a single line of transcription. Audio files use ``.wav`` format.
+
+    Audio files should be in: ``{root_path}/{wavs_path}/{speaker_id}/{file_id}.wav``
+    """
     items = []
     meta_files = glob(f"{os.path.join(root_path, 'txt')}/**/*.txt", recursive=True)
     for meta_file in meta_files:
@@ -497,6 +702,20 @@ def vctk_old(root_path, meta_files=None, wavs_path="wav48", ignored_speakers=Non
 
 
 def synpaflex(root_path, metafiles=None, **kwargs):  # pylint: disable=unused-argument
+    """Normalize the SynPaFlex dataset to TTS format.
+
+    Website: http://synpaflex.irisa.fr/corpus/
+
+    Expected metadata format (individual text files per utterance)::
+
+        wav/file001.wav with corresponding txt/file001.txt: "This is the transcript."
+        wav/file002.wav with corresponding txt/file002.txt: "Another sentence here."
+
+    Note: This dataset automatically searches for all ``.wav`` files recursively in ``root_path``.
+    For each wav file, it looks for a corresponding ``.txt`` file in a ``txt`` folder.
+
+    Audio files are located at: ``{root_path}/**/*.wav``
+    """
     items = []
     speaker_name = "synpaflex"
     root_path = os.path.join(root_path, "")
@@ -516,7 +735,21 @@ def synpaflex(root_path, metafiles=None, **kwargs):  # pylint: disable=unused-ar
 
 
 def open_bible(root_path, meta_files="train", ignore_digits_sentences=True, ignored_speakers=None):
-    """ToDo: Refer the paper when available"""
+    """Normalize the BibleTTS dataset to TTS format.
+
+    Website: https://masakhane-io.github.io/bibleTTS/
+
+    Expected metadata format (individual text files per utterance)::
+
+        train/speaker1/file001.txt: "This is the transcript."
+        train/speaker1/file002.txt: "Another sentence here."
+
+    Note: This dataset automatically searches for all ``.txt`` files in ``{root_path}/{split}/``.
+    Each text file contains a single line of transcription. Audio files use ``.flac`` format.
+    By default, sentences containing digits are ignored.
+
+    Audio files should be in: ``{root_path}/{split}/{speaker_id}/{file_id}.flac``
+    """
     items = []
     split_dir = meta_files
     meta_files = glob(f"{os.path.join(root_path, split_dir)}/**/*.txt", recursive=True)
@@ -538,7 +771,20 @@ def open_bible(root_path, meta_files="train", ignore_digits_sentences=True, igno
 
 
 def mls(root_path, meta_files=None, ignored_speakers=None):
-    """http://www.openslr.org/94/"""
+    """Normalize the Multilingual LibriSpeech (MLS) dataset to TTS format.
+
+    Website: http://www.openslr.org/94/
+
+    Expected metadata format (tab-delimited, no header)::
+
+        speaker_book_utterance	This is the transcript.
+        1001_1234_000001	Another sentence here.
+
+    Note: ``.wav`` is automatically appended to the file ID. Speaker and book IDs
+    are extracted from the filename.
+
+    Audio files should be in: ``{root_path}/{meta_files_dir}/audio/{speaker}/{book}/{filename}.wav``
+    """
     items = []
     with open(os.path.join(root_path, meta_files), encoding="utf-8") as meta:
         for line in meta:
@@ -558,15 +804,29 @@ def mls(root_path, meta_files=None, ignored_speakers=None):
 
 # ======================================== VOX CELEB ===========================================
 def voxceleb2(root_path, meta_file=None, **kwargs):  # pylint: disable=unused-argument
-    """
-    :param meta_file   Used only for consistency with load_tts_samples api
+    """Normalize the VoxCeleb2 dataset to TTS format.
+
+    Website: https://www.robots.ox.ac.uk/~vgg/data/voxceleb/vox2.html
+
+    Note: This dataset automatically searches for all ``.wav`` files recursively in ``root_path``
+    and creates a cached metadata file. No transcriptions are provided (used for speaker encoder training).
+    Speaker IDs are extracted from the folder structure.
+
+    Audio files should be in: ``{root_path}/id{speaker_id}/{video_id}/{utterance_id}.wav``
     """
     return _voxcel_x(root_path, meta_file, voxcel_idx="2")
 
 
 def voxceleb1(root_path, meta_file=None, **kwargs):  # pylint: disable=unused-argument
-    """
-    :param meta_file   Used only for consistency with load_tts_samples api
+    """Normalize the VoxCeleb1 dataset to TTS format.
+
+    Website: https://www.robots.ox.ac.uk/~vgg/data/voxceleb/vox1.html
+
+    Note: This dataset automatically searches for all ``.wav`` files recursively in ``root_path``
+    and creates a cached metadata file. No transcriptions are provided (used for speaker encoder training).
+    Speaker IDs are extracted from the folder structure.
+
+    Audio files should be in: ``{root_path}/id{speaker_id}/{video_id}/{utterance_id}.wav``
     """
     return _voxcel_x(root_path, meta_file, voxcel_idx="1")
 
@@ -607,7 +867,18 @@ def _voxcel_x(root_path, meta_file, voxcel_idx):
 
 
 def emotion(root_path, meta_file, ignored_speakers=None):
-    """Generic emotion dataset"""
+    """Normalize a generic emotion dataset to TTS format.
+
+    Expected metadata format (comma-delimited with header)::
+
+        file_path,speaker_id,emotion_id
+        audio/speaker1/file001.wav,speaker1,happy
+        audio/speaker2/file002.wav,speaker2,sad
+
+    Note: No text transcriptions are included, only emotion labels.
+
+    Audio files are located at: ``{root_path}/{file_path}``
+    """
     txt_file = os.path.join(root_path, meta_file)
     items = []
     with open(txt_file, encoding="utf-8") as ttf:
@@ -629,7 +900,16 @@ def emotion(root_path, meta_file, ignored_speakers=None):
 
 
 def baker(root_path: str, meta_file: str, **kwargs) -> list[list[str]]:  # pylint: disable=unused-argument
-    """Normalizes the Baker meta data file to TTS format
+    """Normalize the Baker Chinese TTS dataset to TTS format.
+
+    Website: https://www.data-baker.com/data/index/TNtts/
+
+    Expected metadata format (pipe-delimited)::
+
+        000001|This is the Chinese transcript.
+        000002|Another sentence here.
+
+    Audio files should be in: ``{root_path}/clips_22/{filename}.wav``
 
     Args:
         root_path (str): path to the baker dataset
@@ -649,7 +929,20 @@ def baker(root_path: str, meta_file: str, **kwargs) -> list[list[str]]:  # pylin
 
 
 def kokoro(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
-    """Japanese single-speaker dataset from https://github.com/kaiidams/Kokoro-Speech-Dataset"""
+    """Normalize the Kokoro Japanese Speech dataset to TTS format.
+
+    Website: https://github.com/kaiidams/Kokoro-Speech-Dataset
+
+    Expected metadata format (pipe-delimited)::
+
+        file001|raw transcript|normalized transcript
+        file002|raw transcript|normalized transcript
+
+    Note: ``.wav`` is automatically appended to the file ID. The normalized transcript
+    (third column) is used with spaces removed.
+
+    Audio files should be in: ``{root_path}/wavs/{filename}.wav``
+    """
     txt_file = os.path.join(root_path, meta_file)
     items = []
     speaker_name = "kokoro"
@@ -663,7 +956,20 @@ def kokoro(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
 
 
 def kss(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
-    """Korean single-speaker dataset from https://www.kaggle.com/datasets/bryanpark/korean-single-speaker-speech-dataset"""
+    """Normalize the Korean Single Speaker (KSS) dataset to TTS format.
+
+    Website: https://www.kaggle.com/datasets/bryanpark/korean-single-speaker-speech-dataset
+
+    Expected metadata format (pipe-delimited)::
+
+        audio/file001.wav|raw transcript|normalized transcript
+        audio/file002.wav|raw transcript|normalized transcript
+
+    Note: The full audio file path (relative to ``root_path``) is included in the metadata.
+    Only the normalized transcript (third column) is used.
+
+    Audio files are located at: ``{root_path}/{filepath}``
+    """
     txt_file = os.path.join(root_path, meta_file)
     items = []
     speaker_name = "kss"
@@ -677,6 +983,17 @@ def kss(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
 
 
 def bel_tts_formatter(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
+    """Normalize the Belarusian TTS dataset to TTS format.
+
+    Expected metadata format (pipe-delimited)::
+
+        audio/file001.wav|This is the Belarusian transcript.
+        audio/file002.wav|Another sentence here.
+
+    Note: The full audio file path (relative to ``root_path``) is included in the metadata.
+
+    Audio files are located at: ``{root_path}/{filepath}``
+    """
     txt_file = os.path.join(root_path, meta_file)
     items = []
     speaker_name = "bel_tts"

--- a/docs/source/datasets/formatting_your_dataset.md
+++ b/docs/source/datasets/formatting_your_dataset.md
@@ -4,10 +4,12 @@
 For training a TTS model, you need a dataset with speech recordings and
 transcriptions. The speech must be divided into audio clips and each clip needs
 a transcription.
-
-If you have a single audio file and you need to split it into clips, there are different open-source tools for you. We recommend Audacity. It is an open-source and free audio editing software.
-
 It is also important to use a lossless audio file format to prevent compression artifacts. We recommend using `wav` file format.
+
+```{note}
+If you have a single audio file and you need to split it into clips, there are
+different open-source tools for you. We recommend [Audacity](https://www.audacityteam.org/). It is an open-source and free audio editing software.
+```
 
 Let's assume you created the audio clips and their transcription. You can collect all your clips in a folder. Let's call this folder `wavs`.
 
@@ -21,7 +23,8 @@ Let's assume you created the audio clips and their transcription. You can collec
 
 You can either create separate transcription files for each clip or create a text file that maps each audio clip to its transcription. In this file, each column must be delimited by a special character separating the audio file name, the transcription and the normalized transcription. And make sure that the delimiter is not used in the transcription text.
 
-We recommend the following format delimited by `|`. In the following example, `audio1`, `audio2` refer to files `audio1.wav`, `audio2.wav` etc.
+We recommend the following format delimited by `|`. In the following example,
+`audio1`, `audio2` refer to files `audio1.wav`, `audio2.wav` etc.
 
 ```
 # metadata.txt
@@ -31,10 +34,16 @@ audio2|1469 and 1470|fourteen sixty-nine and fourteen seventy
 audio3|It'll be $16 sir.|It'll be sixteen dollars sir.
 ...
 ```
-*If you don't have normalized transcriptions, you can use the same transcription for both columns. If it's your case, we recommend to use normalization later in the pipeline, either in the text cleaner or in the phonemizer.*
 
+```{note}
+If you don't have normalized transcriptions with numbers and abbreviations
+spelled out, you can use the same transcription for both columns. In this
+case, we recommend to use normalization later in the pipeline, either in the
+text cleaner or in the phonemizer. Just make sure your metadata file still has three
+columns.
+```
 
-In the end, we have the following folder structure
+In the end, we have the following folder structure:
 ```
 /MyTTSDataset
       |
@@ -45,23 +54,27 @@ In the end, we have the following folder structure
               | ...
 ```
 
-The format above is taken from widely-used the [LJSpeech](https://keithito.com/LJ-Speech-Dataset/) dataset. You can also download and see the dataset. 🐸TTS already provides tooling for the LJSpeech. if you use the same format, you can start training your models right away.
+The metadata format above is taken from the widely-used
+[LJSpeech](https://keithito.com/LJ-Speech-Dataset/) dataset. 🐸TTS already
+provides tooling for LJSpeech, so if you use the same format, you can start training your models right away.
 
-## Dataset Quality
-
+```{note}
 Your dataset should have good coverage of the target language. It should cover the phonemic variety, exceptional sounds and syllables. This is extremely important for especially non-phonemic languages like English.
 
 For more info about dataset qualities and properties check [this page](what_makes_a_good_dataset.md).
+```
 
 ## Using Your Dataset in 🐸TTS
 
-After you collect and format your dataset, you need to check two things. Whether you need a `formatter` and a `text_cleaner`. The `formatter` loads the text file (created above) as a list and the `text_cleaner` performs a sequence of text normalization operations that converts the raw text into the spoken representation (e.g. converting numbers to text, acronyms, and symbols to the spoken format).
+After you collect and format your dataset, you need to check two things. Whether you need a `formatter` and a `text_cleaner`. The `formatter` loads the metadata file (created above) as a list and the `text_cleaner` performs a sequence of text normalization operations that converts the raw text into the spoken representation (e.g. converting numbers to text, acronyms, and symbols to the spoken format).
 
-If you use a different dataset format than the LJSpeech or the other public datasets that 🐸TTS supports, then you need to write your own `formatter`.
+If you use a different dataset format than LJSpeech or the other public datasets
+that 🐸TTS supports, then you need to write your own `formatter`. See the
+[list of already available formatters](#available-formatters) below.
 
 If your dataset is in a new language or it needs special normalization steps, then you need a new `text_cleaner`.
 
-What you get out of a `formatter` is a `List[Dict]` in the following format.
+A `formatter` returns a list of dictionaries:
 
 ```
 >>> formatter(metafile_path)
@@ -72,9 +85,10 @@ What you get out of a `formatter` is a `List[Dict]` in the following format.
 ]
 ```
 
-Each sub-list is parsed as ```{"<filename>", "<transcription>", "<speaker_name">]```.
-```<speaker_name>``` is the dataset name for single speaker datasets and it is mainly used
-in the multi-speaker models to map the speaker of the each sample. But for now, we only focus on single speaker datasets.
+`audio_file` is the path to the audio file, `text` contains its transcription
+and `speaker_name` is used in multi-speaker models to identify the speaker of
+each sample. For single-speaker datasets `speaker_name` can simply store the
+dataset name.
 
 The purpose of a `formatter` is to parse your manifest file and load the audio file paths and transcriptions.
 Then, the output is passed to the `Dataset`. It computes features from the audio signals, calls text normalization routines, and converts raw text to
@@ -82,7 +96,9 @@ phonemes if needed.
 
 ## Loading your dataset
 
-Load one of the dataset supported by 🐸TTS.
+Load one of the dataset supported by 🐸TTS. You can also consult the
+[recipes](https://github.com/idiap/coqui-ai-TTS/tree/dev/recipes) Coqui already
+provides for many datasets.
 
 ```python
 from TTS.tts.configs.shared_configs import BaseDatasetConfig
@@ -134,3 +150,15 @@ See `TTS.vocoder.datasets.*`, for different `Dataset` implementations for the `v
 See {py:class}`~TTS.utils.audio.AudioProcessor`, which includes all the audio
 processing and feature extraction functions used in a `Dataset` implementation.
 Feel free to add things as you need.
+
+## Available Formatters
+
+🐸TTS provides built-in formatters for many popular datasets. Each formatter
+knows how to parse a specific dataset's metadata format. You can also use them
+as a starting point to write a custom formatter for your own dataset.
+
+```{eval-rst}
+.. automodule:: TTS.tts.datasets.formatters
+   :members:
+   :exclude-members: Formatter, register_formatter, ljspeech_test
+```

--- a/docs/source/training/training_a_model.md
+++ b/docs/source/training/training_a_model.md
@@ -13,13 +13,15 @@
     {py:class}`~TTS.tts.models.tacotron.Tacotron` model then see the
     {py:class}`~TTS.tts.configs.tacotron_config.TacotronConfig` class and make sure you understand it.
 
-3. Check the recipes.
+3. Check the existing recipes.
 
-    Recipes are located under `TTS/recipes/`. They do not promise perfect models
+    Coqui already has
+    [training recipes](https://github.com/idiap/coqui-ai-TTS/tree/dev/recipes) for
+    many datasets. They do not promise perfect models
     but they provide a good start point. A recipe for
     {py:class}`~TTS.tts.models.glow_tts.GlowTTS` using the [LJ Speech
-    dataset](https://keithito.com/LJ-Speech-Dataset/) looks like below. Let's be
-    creative and call this `train_glowtts.py`.
+    dataset](https://keithito.com/LJ-Speech-Dataset/), which we'll name
+    `train_glowtts.py`, looks like this:
 
     ```{literalinclude} ../../../recipes/ljspeech/glow_tts/train_glowtts.py
     ```

--- a/tests/data_tests/test_dataset_formatters.py
+++ b/tests/data_tests/test_dataset_formatters.py
@@ -11,10 +11,10 @@ class TestTTSFormatters(unittest.TestCase):
         meta_file = "common_voice.tsv"
         items = common_voice(root_path, meta_file)
         assert items[0]["text"] == "The applicants are invited for coffee and visa is given immediately."
-        assert items[0]["audio_file"] == os.path.join(get_tests_input_path(), "clips", "common_voice_en_20005954.wav")
+        assert items[0]["audio_file"] == os.path.join(get_tests_input_path(), "clips", "common_voice_en_20005954.mp3")
 
         assert items[-1]["text"] == "Competition for limited resources has also resulted in some local conflicts."
-        assert items[-1]["audio_file"] == os.path.join(get_tests_input_path(), "clips", "common_voice_en_19737074.wav")
+        assert items[-1]["audio_file"] == os.path.join(get_tests_input_path(), "clips", "common_voice_en_19737074.mp3")
 
     def test_custom_formatter_with_existing_name(self):
         def custom_formatter(root_path, meta_file, ignored_speakers=None):


### PR DESCRIPTION
Add expected metadata format to the docstrings and show those in the documentation: https://coqui-tts.readthedocs.io/en/latest/datasets/formatting_your_dataset.html

Also show a better error message when the `ljspeech` formatter is used with less than 3 columns, which is a very frequent user error.