### PR TITLE
fix(bark): ensure tensors are on same device when not using reference audio

### DIFF
--- a/TTS/tts/layers/bark/inference_funcs.py
+++ b/TTS/tts/layers/bark/inference_funcs.py
@@ -101,7 +101,7 @@ def generate_text_semantic(
             value=model.config.SEMANTIC_PAD_TOKEN,
         )
     else:
-        semantic_history = torch.full((256,), model.config.SEMANTIC_PAD_TOKEN, dtype=torch.int64)
+        semantic_history = torch.full((256,), model.config.SEMANTIC_PAD_TOKEN, dtype=torch.int64, device=model.device)
     x = torch.cat(
         [encoded_text, semantic_history, torch.tensor([model.config.SEMANTIC_INFER_TOKEN], device=model.device)]
     ).unsqueeze(0)


### PR DESCRIPTION
The previous fix only worked when reference audio was provided.