### PR TITLE
fix(audio): create parent folders, improve error message

### DIFF
--- a/TTS/bin/synthesize.py
+++ b/TTS/bin/synthesize.py
@@ -4,6 +4,7 @@
 
 import argparse
 import contextlib
+import importlib.metadata
 import logging
 import sys
 from argparse import RawTextHelpFormatter
@@ -288,7 +289,12 @@ def parse_args(arg_list: list[str] | None) -> argparse.Namespace:
         "--voice_dir",
         type=str,
         default=None,
-        help="Voice dir for tortoise model",
+        help="Custom directory for caching of cloned voices.",
+    )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print the Coqui TTS version number and exit.",
     )
 
     args = parser.parse_args(arg_list)
@@ -304,6 +310,7 @@ def parse_args(arg_list: list[str] | None) -> argparse.Namespace:
         args.model_info_by_name,
         args.source_wav,
         args.target_wav,
+        args.version,
     ]
     if not any(check_args):
         parser.parse_args(["-h"])
@@ -337,6 +344,11 @@ def main(arg_list: list[str] | None = None) -> None:
         vc_path = None
         vc_config_path = None
         model_dir = None
+
+        # 0) Print version number
+        if args.version:
+            logger.info(importlib.metadata.version("coqui-tts"))
+            sys.exit(0)
 
         # 1) List pre-trained TTS models
         if args.list_models:

--- a/tests/aux_tests/test_audio_processor.py
+++ b/tests/aux_tests/test_audio_processor.py
@@ -54,7 +54,9 @@ def test_audio_synthesis(tmp_path, ap, norms):
         f"symmetric_{symmetric_norm}-clip_norm_{clip_norm}.wav"
     )
     print(" | > Creating wav file at : ", file_name)
-    ap.save_wav(wav_, tmp_path / file_name)
+    with pytest.raises(IsADirectoryError, match="Output path must be a file"):
+        ap.save_wav(wav_, tmp_path)
+    ap.save_wav(wav_, tmp_path / "subdir_to_be_created" / file_name)
 
 
 def test_normalize(ap):

--- a/tests/inference_tests/test_synthesize.py
+++ b/tests/inference_tests/test_synthesize.py
@@ -6,6 +6,7 @@ def test_synthesize(tmp_path):
     """Test synthesize.py with diffent arguments."""
     output_path = str(tmp_path / "output.wav")
 
+    run_main(main, ["--version"])
     run_main(main, ["--list_models"])
 
     # single speaker model


### PR DESCRIPTION
- If necessary, create parent folders when saving wav files.
- Return a clear error message when the specified output path is a folder instead of a file.
- `tts --version` now prints the current coqui-tts version.