### PR TITLE
Unify model conditioning inputs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        subset: ["data_tests", "inference_tests", "test_aux", "test_text", "test_vc", "test_vocoder"]
+        subset: ["data_tests", "inference_tests", "test_aux", "test_text", "test_tts", "test_vc", "test_vocoder"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup uv

--- a/TTS/config/shared_configs.py
+++ b/TTS/config/shared_configs.py
@@ -265,3 +265,8 @@ class BaseTrainingConfig(TrainerConfig):
     num_loader_workers: int = 0
     num_eval_loader_workers: int = 0
     use_noise_augment: bool = False
+
+
+@dataclass
+class ModelArgs(Coqpit):
+    """Parameters necessary for model instantiation."""

--- a/TTS/tts/configs/delightful_tts_config.py
+++ b/TTS/tts/configs/delightful_tts_config.py
@@ -56,7 +56,6 @@ class DelightfulTTSConfig(BaseTTSConfig):
         use_speaker_embedding (bool): Whether to use speaker embedding.
         speakers_file (str): Path to the speaker file.
         speaker_embedding_channels (int): Number of channels for the speaker embedding.
-        language_ids_file (str): Path to the language IDs file.
     """
 
     model: str = "delightful_tts"
@@ -130,8 +129,6 @@ class DelightfulTTSConfig(BaseTTSConfig):
     use_speaker_embedding: bool = False
     speakers_file: str = None
     speaker_embedding_channels: int = 256
-    language_ids_file: str = None
-    use_language_embedding: bool = False
 
     # use d-vectors
     use_d_vector_file: bool = False

--- a/TTS/tts/configs/shared_configs.py
+++ b/TTS/tts/configs/shared_configs.py
@@ -9,6 +9,7 @@ from TTS.config import (
     BaseTrainingConfig,
     get_from_config_or_model_args,
 )
+from TTS.config.shared_configs import ModelArgs
 
 
 @dataclass
@@ -303,7 +304,7 @@ class BaseTTSConfig(BaseTrainingConfig):
     """
 
     audio: BaseAudioConfig = field(default_factory=BaseAudioConfig)
-    model_args: Coqpit | None = None
+    model_args: ModelArgs = field(default_factory=ModelArgs)
     _supports_cloning: bool = False
     # phoneme settings
     use_phonemes: bool = False

--- a/TTS/tts/configs/shared_configs.py
+++ b/TTS/tts/configs/shared_configs.py
@@ -7,7 +7,6 @@ from TTS.config import (
     BaseAudioConfig,
     BaseDatasetConfig,
     BaseTrainingConfig,
-    get_from_config_or_model_args,
 )
 from TTS.config.shared_configs import ModelArgs
 
@@ -358,6 +357,6 @@ class BaseTTSConfig(BaseTrainingConfig):
     @property
     def supports_cloning(self) -> bool:
         return self._supports_cloning or (
-            Path(get_from_config_or_model_args(self, "speaker_encoder_model_path", "")).is_file()
-            and Path(get_from_config_or_model_args(self, "speaker_encoder_config_path", "")).is_file()
+            Path(self.model_args.get("speaker_encoder_model_path", "")).is_file()
+            and Path(self.model_args.get("speaker_encoder_config_path", "")).is_file()
         )

--- a/TTS/tts/configs/vits_config.py
+++ b/TTS/tts/configs/vits_config.py
@@ -90,12 +90,6 @@ class VitsConfig(BaseTTSConfig):
         test_sentences (List[List]):
             List of sentences with speaker and language information to be used for testing.
 
-        language_ids_file (str):
-            Path to the language ids file.
-
-        use_language_embedding (bool):
-            If true, language embedding is used. Defaults to `False`.
-
     Note:
         Check :class:`TTS.tts.configs.shared_configs.BaseTTSConfig` for the inherited parameters.
 
@@ -161,8 +155,6 @@ class VitsConfig(BaseTTSConfig):
     use_speaker_embedding: bool = False
     speakers_file: str | None = None
     speaker_embedding_channels: int = 256
-    language_ids_file: str | None = None
-    use_language_embedding: bool = False
 
     # use d-vectors
     use_d_vector_file: bool = False

--- a/TTS/tts/layers/delightful_tts/acoustic_model.py
+++ b/TTS/tts/layers/delightful_tts/acoustic_model.py
@@ -194,19 +194,6 @@ class AcousticModel(torch.nn.Module):
 
         return sid, g, lid, durations
 
-    def _set_speaker_input(self, aux_input: dict):
-        d_vectors = aux_input.get("d_vectors", None)
-        speaker_ids = aux_input.get("speaker_ids", None)
-
-        if d_vectors is not None and speaker_ids is not None:
-            raise ValueError("[!] Cannot use d-vectors and speaker-ids together.")
-
-        if speaker_ids is not None and not hasattr(self, "emb_g"):
-            raise ValueError("[!] Cannot use speaker-ids without enabling speaker embedding.")
-
-        g = speaker_ids if speaker_ids is not None else d_vectors
-        return g
-
     # def set_embedding_dims(self):
     #     if self.embedded_speaker_dim > 0:
     #         self.embedding_dims = self.embedded_speaker_dim

--- a/TTS/tts/layers/vits/networks.py
+++ b/TTS/tts/layers/vits/networks.py
@@ -3,7 +3,7 @@ import math
 import torch
 from torch import nn
 
-from TTS.tts.layers.glow_tts.glow import WN
+from TTS.tts.layers.generic.wavenet import WN
 from TTS.tts.layers.glow_tts.transformer import RelativePositionTransformer
 from TTS.tts.utils.helpers import sequence_mask
 

--- a/TTS/tts/layers/xtts/trainer/gpt_trainer.py
+++ b/TTS/tts/layers/xtts/trainer/gpt_trainer.py
@@ -361,42 +361,39 @@ class GPTTrainer(BaseTTS):
         num_gpus: int,
         rank: int | None = None,
     ) -> "DataLoader":  # pylint: disable=W0613
-        if is_eval and not config.run_eval:
-            loader = None
+        # init dataloader
+        dataset = XTTSDataset(self.config, samples, self.xtts.tokenizer, config.audio.sample_rate, is_eval)
+
+        # wait all the DDP process to be ready
+        if num_gpus > 1:
+            torch.distributed.barrier()
+
+        # sort input sequences from short to long
+        # dataset.preprocess_samples()
+
+        # get samplers
+        sampler = self.get_sampler(dataset, num_gpus)
+
+        # ignore sampler when is eval because if we changed the sampler parameter we will not be able to compare previous runs
+        if sampler is None or is_eval:
+            loader = DataLoader(
+                dataset,
+                batch_size=config.eval_batch_size if is_eval else config.batch_size,
+                shuffle=False,
+                drop_last=False,
+                collate_fn=dataset.collate_fn,
+                num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
+                pin_memory=False,
+            )
         else:
-            # init dataloader
-            dataset = XTTSDataset(self.config, samples, self.xtts.tokenizer, config.audio.sample_rate, is_eval)
-
-            # wait all the DDP process to be ready
-            if num_gpus > 1:
-                torch.distributed.barrier()
-
-            # sort input sequences from short to long
-            # dataset.preprocess_samples()
-
-            # get samplers
-            sampler = self.get_sampler(dataset, num_gpus)
-
-            # ignore sampler when is eval because if we changed the sampler parameter we will not be able to compare previous runs
-            if sampler is None or is_eval:
-                loader = DataLoader(
-                    dataset,
-                    batch_size=config.eval_batch_size if is_eval else config.batch_size,
-                    shuffle=False,
-                    drop_last=False,
-                    collate_fn=dataset.collate_fn,
-                    num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
-                    pin_memory=False,
-                )
-            else:
-                loader = DataLoader(
-                    dataset,
-                    sampler=sampler,
-                    batch_size=config.eval_batch_size if is_eval else config.batch_size,
-                    collate_fn=dataset.collate_fn,
-                    num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
-                    pin_memory=False,
-                )
+            loader = DataLoader(
+                dataset,
+                sampler=sampler,
+                batch_size=config.eval_batch_size if is_eval else config.batch_size,
+                collate_fn=dataset.collate_fn,
+                num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
+                pin_memory=False,
+            )
         return loader
 
     def get_optimizer(self) -> list:

--- a/TTS/tts/models/align_tts.py
+++ b/TTS/tts/models/align_tts.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass, field
 
 import torch
-from coqpit import Coqpit
 from monotonic_alignment_search import maximum_path
 from torch import nn
 
+from TTS.config.shared_configs import ModelArgs
 from TTS.tts.layers.align_tts.mdn import MDNBlock
 from TTS.tts.layers.feed_forward.decoder import Decoder
 from TTS.tts.layers.feed_forward.duration_predictor import DurationPredictor
@@ -18,7 +18,7 @@ from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
 
 
 @dataclass
-class AlignTTSArgs(Coqpit):
+class AlignTTSArgs(ModelArgs):
     """
     Args:
         num_chars (int):

--- a/TTS/tts/models/base_tts.py
+++ b/TTS/tts/models/base_tts.py
@@ -147,7 +147,7 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
             "language": language,
         }
 
-    def format_batch(self, batch: dict) -> dict:
+    def format_batch(self, batch: dict[str, Any]) -> dict[str, Any]:
         """Generic batch formatting for `TTSDataset`.
 
         You must override this if you use a custom dataset.
@@ -274,77 +274,73 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
         num_gpus: int,
         rank: int | None = None,
     ) -> "DataLoader":
-        if is_eval and not config.run_eval:
-            loader = None
+        # setup multi-speaker attributes
+        if self.speaker_manager is not None:
+            if config.model_args is not None:
+                speaker_id_mapping = (
+                    self.speaker_manager.name_to_id if config.model_args.use_speaker_embedding else None
+                )
+                d_vector_mapping = self.speaker_manager.embeddings if config.model_args.use_d_vector_file else None
+                config.use_d_vector_file = config.model_args.use_d_vector_file
+            else:
+                speaker_id_mapping = self.speaker_manager.name_to_id if config.use_speaker_embedding else None
+                d_vector_mapping = self.speaker_manager.embeddings if config.use_d_vector_file else None
         else:
-            # setup multi-speaker attributes
-            if self.speaker_manager is not None:
-                if config.model_args is not None:
-                    speaker_id_mapping = (
-                        self.speaker_manager.name_to_id if config.model_args.use_speaker_embedding else None
-                    )
-                    d_vector_mapping = self.speaker_manager.embeddings if config.model_args.use_d_vector_file else None
-                    config.use_d_vector_file = config.model_args.use_d_vector_file
-                else:
-                    speaker_id_mapping = self.speaker_manager.name_to_id if config.use_speaker_embedding else None
-                    d_vector_mapping = self.speaker_manager.embeddings if config.use_d_vector_file else None
-            else:
-                speaker_id_mapping = None
-                d_vector_mapping = None
+            speaker_id_mapping = None
+            d_vector_mapping = None
 
-            # setup multi-lingual attributes
-            if self.language_manager is not None:
-                language_id_mapping = self.language_manager.name_to_id if self.args.use_language_embedding else None
-            else:
-                language_id_mapping = None
+        # setup multi-lingual attributes
+        if self.language_manager is not None:
+            language_id_mapping = self.language_manager.name_to_id if self.args.use_language_embedding else None
+        else:
+            language_id_mapping = None
 
-            # init dataloader
-            dataset = TTSDataset(
-                outputs_per_step=config.r if "r" in config else 1,
-                compute_linear_spec=config.model.lower() == "tacotron" or config.compute_linear_spec,
-                compute_f0=config.get("compute_f0", False),
-                f0_cache_path=config.get("f0_cache_path", None),
-                compute_energy=config.get("compute_energy", False),
-                energy_cache_path=config.get("energy_cache_path", None),
-                samples=samples,
-                ap=self.ap,
-                return_wav=config.return_wav if "return_wav" in config else False,
-                batch_group_size=0 if is_eval else config.batch_group_size * config.batch_size,
-                min_text_len=config.min_text_len,
-                max_text_len=config.max_text_len,
-                min_audio_len=config.min_audio_len,
-                max_audio_len=config.max_audio_len,
-                phoneme_cache_path=config.phoneme_cache_path,
-                precompute_num_workers=config.precompute_num_workers,
-                use_noise_augment=False if is_eval else config.use_noise_augment,
-                speaker_id_mapping=speaker_id_mapping,
-                d_vector_mapping=d_vector_mapping if config.use_d_vector_file else None,
-                tokenizer=self.tokenizer,
-                start_by_longest=config.start_by_longest,
-                language_id_mapping=language_id_mapping,
-            )
+        # init dataloader
+        dataset = TTSDataset(
+            outputs_per_step=config.r if "r" in config else 1,
+            compute_linear_spec=config.model.lower() == "tacotron" or config.compute_linear_spec,
+            compute_f0=config.get("compute_f0", False),
+            f0_cache_path=config.get("f0_cache_path", None),
+            compute_energy=config.get("compute_energy", False),
+            energy_cache_path=config.get("energy_cache_path", None),
+            samples=samples,
+            ap=self.ap,
+            return_wav=config.return_wav if "return_wav" in config else False,
+            batch_group_size=0 if is_eval else config.batch_group_size * config.batch_size,
+            min_text_len=config.min_text_len,
+            max_text_len=config.max_text_len,
+            min_audio_len=config.min_audio_len,
+            max_audio_len=config.max_audio_len,
+            phoneme_cache_path=config.phoneme_cache_path,
+            precompute_num_workers=config.precompute_num_workers,
+            use_noise_augment=False if is_eval else config.use_noise_augment,
+            speaker_id_mapping=speaker_id_mapping,
+            d_vector_mapping=d_vector_mapping if config.use_d_vector_file else None,
+            tokenizer=self.tokenizer,
+            start_by_longest=config.start_by_longest,
+            language_id_mapping=language_id_mapping,
+        )
 
-            # wait all the DDP process to be ready
-            if num_gpus > 1:
-                dist.barrier()
+        # wait all the DDP process to be ready
+        if num_gpus > 1:
+            dist.barrier()
 
-            # sort input sequences from short to long
-            dataset.preprocess_samples()
+        # sort input sequences from short to long
+        dataset.preprocess_samples()
 
-            # get samplers
-            sampler = self.get_sampler(config, dataset, num_gpus)
+        # get samplers
+        sampler = self.get_sampler(config, dataset, num_gpus)
 
-            loader = DataLoader(
-                dataset,
-                batch_size=config.eval_batch_size if is_eval else config.batch_size,
-                shuffle=config.shuffle if sampler is None else False,  # if there is no other sampler
-                collate_fn=dataset.collate_fn,
-                drop_last=config.drop_last,  # setting this False might cause issues in AMP training.
-                sampler=sampler,
-                num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
-                pin_memory=False,
-            )
-        return loader
+        return DataLoader(
+            dataset,
+            batch_size=config.eval_batch_size if is_eval else config.batch_size,
+            shuffle=config.shuffle if sampler is None else False,  # if there is no other sampler
+            collate_fn=dataset.collate_fn,
+            drop_last=config.drop_last,  # setting this False might cause issues in AMP training.
+            sampler=sampler,
+            num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
+            pin_memory=False,
+        )
 
     def _create_logs(
         self, batch: dict[str, Any], outputs: dict[str, Any] | list[dict[str, Any]]

--- a/TTS/tts/models/base_tts.py
+++ b/TTS/tts/models/base_tts.py
@@ -13,6 +13,7 @@ from trainer.logging.base_dash_logger import BaseDashboardLogger
 from trainer.torch import DistributedSampler, DistributedSamplerWrapper
 
 from TTS.config import get_from_config_or_model_args
+from TTS.config.shared_configs import ModelArgs
 from TTS.model import BaseTrainerModel
 from TTS.tts.configs.shared_configs import BaseTTSConfig
 from TTS.tts.datasets.dataset import TTSDataset
@@ -51,9 +52,9 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
         self.tokenizer = tokenizer
         self.speaker_manager = speaker_manager
         self.language_manager = language_manager
-        self._set_model_args(config)
+        self._set_model_args()
 
-    def _set_model_args(self, config: Coqpit):
+    def _set_model_args(self) -> None:
         """Setup model args based on the config type (`ModelConfig` or `ModelArgs`).
 
         `ModelArgs` has all the fields required to initialize the model architecture.
@@ -65,22 +66,15 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
 
         If the config is for the model with a name like "*Args", then we assign them directly.
         """
-        # don't use isinstance not to import recursively
-        if "Config" in config.__class__.__name__:
-            config_num_chars = (
-                self.config.model_args.num_chars if self.config.model_args is not None else self.config.num_chars
-            )
+        if isinstance(self.config, BaseTTSConfig):
+            config_num_chars = get_from_config_or_model_args(self.config, "num_chars")
             num_chars = config_num_chars if self.tokenizer is None else self.tokenizer.characters.num_chars
-            if "characters" in config:
+            if "characters" in self.config:
                 self.config.num_chars = num_chars
-                if self.config.model_args is not None:
-                    config.model_args.num_chars = num_chars
-                    self.args = self.config.model_args
-            else:
-                self.config = config
-                self.args = config.model_args
-        elif "Args" in config.__class__.__name__:
-            self.args = config
+                self.config.model_args.num_chars = num_chars
+            self.args = self.config.model_args
+        elif isinstance(self.config, ModelArgs):
+            self.args = self.config
         else:
             raise ValueError("config must be either a *Config or *Args")
 
@@ -120,8 +114,6 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
             self.speaker_embedding.weight.data.normal_(0, 0.3)
 
     def get_aux_input_from_test_sentences(self, sentence_info: str | list[str]) -> dict[str, Any]:
-        config = self.config.model_args if self.config.model_args is not None else self.config
-
         # extract speaker and language info
         text, speaker, style_wav, language = None, None, None, None
 
@@ -276,15 +268,15 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
     ) -> "DataLoader":
         # setup multi-speaker attributes
         if self.speaker_manager is not None:
-            if config.model_args is not None:
-                speaker_id_mapping = (
-                    self.speaker_manager.name_to_id if config.model_args.use_speaker_embedding else None
-                )
-                d_vector_mapping = self.speaker_manager.embeddings if config.model_args.use_d_vector_file else None
-                config.use_d_vector_file = config.model_args.use_d_vector_file
-            else:
-                speaker_id_mapping = self.speaker_manager.name_to_id if config.use_speaker_embedding else None
-                d_vector_mapping = self.speaker_manager.embeddings if config.use_d_vector_file else None
+            speaker_id_mapping = (
+                self.speaker_manager.name_to_id
+                if get_from_config_or_model_args(config, "use_speaker_embedding")
+                else None
+            )
+            d_vector_mapping = (
+                self.speaker_manager.embeddings if get_from_config_or_model_args(config, "use_d_vector_file") else None
+            )
+            config.use_d_vector_file = get_from_config_or_model_args(config, "use_d_vector_file", False)
         else:
             speaker_id_mapping = None
             d_vector_mapping = None
@@ -456,9 +448,7 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
             output_path = os.path.join(trainer.output_path, "speakers.pth")
             self.speaker_manager.save_ids_to_file(output_path)
             trainer.config.speakers_file = output_path
-            # some models don't have `model_args` set
-            if getattr(trainer.config, "model_args", None) is not None:
-                trainer.config.model_args.speakers_file = output_path
+            trainer.config.model_args.speakers_file = output_path
             trainer.config.save_json(os.path.join(trainer.output_path, "config.json"))
             logger.info("`speakers.pth` is saved to: %s", output_path)
             logger.info("`speakers_file` is updated in the config.json.")
@@ -466,9 +456,7 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
         if self.language_manager is not None:
             output_path = os.path.join(trainer.output_path, "language_ids.json")
             self.language_manager.save_ids_to_file(output_path)
-            trainer.config.language_ids_file = output_path
-            if getattr(trainer.config, "model_args", None) is not None:
-                trainer.config.model_args.language_ids_file = output_path
+            trainer.config.model_args.language_ids_file = output_path
             trainer.config.save_json(os.path.join(trainer.output_path, "config.json"))
             logger.info("`language_ids.json` is saved to: %s", output_path)
             logger.info("`language_ids_file` is updated in the config.json.")
@@ -627,18 +615,16 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
 
 
 class BaseTTSE2E(BaseTTS):
-    def _set_model_args(self, config: Coqpit):
-        self.config = config
-        if "Config" in config.__class__.__name__:
+    def _set_model_args(self) -> None:
+        if isinstance(self.config, BaseTTSConfig):
             num_chars = (
                 self.config.model_args.num_chars if self.tokenizer is None else self.tokenizer.characters.num_chars
             )
             self.config.model_args.num_chars = num_chars
             self.config.num_chars = num_chars
-            self.args = config.model_args
+            self.args = self.config.model_args
             self.args.num_chars = num_chars
-        elif "Args" in config.__class__.__name__:
-            self.args = config
-            self.args.num_chars = self.args.num_chars
+        elif isinstance(self.config, ModelArgs):
+            self.args = self.config
         else:
             raise ValueError("config must be either a *Config or *Args")

--- a/TTS/tts/models/base_tts.py
+++ b/TTS/tts/models/base_tts.py
@@ -79,7 +79,7 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
         else:
             raise ValueError("config must be either a *Config or *Args")
 
-    def init_multispeaker(self, config: Coqpit, data: list = None):
+    def init_multispeaker(self, config: Coqpit):
         """Set up for multi-speaker TTS.
 
         Initialize a speaker embedding layer if needed and define expected embedding

--- a/TTS/tts/models/base_tts.py
+++ b/TTS/tts/models/base_tts.py
@@ -1,12 +1,13 @@
 import logging
 import os
 import random
-from typing import Any
+from typing import Any, Literal
 
 import torch
 import torch.distributed as dist
 from coqpit import Coqpit
 from torch import nn
+from torch.nn import functional as F
 from torch.utils.data import DataLoader
 from torch.utils.data.sampler import WeightedRandomSampler
 from trainer.logging.base_dash_logger import BaseDashboardLogger
@@ -501,7 +502,7 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
 
         if len(self.speaker_manager.name_to_id) == 1:
             speaker_id = list(self.speaker_manager.name_to_id.values())[0]
-            return torch.tensor(speaker_id, device=self.device), None
+            return torch.tensor([speaker_id], device=self.device), None
 
         speaker_exists = True
         if get_from_config_or_model_args(self.config, "use_d_vector_file") and speaker is not None:
@@ -514,7 +515,7 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
         if get_from_config_or_model_args(self.config, "use_speaker_embedding") and speaker is not None:
             if speaker in self.speaker_manager.name_to_id:
                 speaker_id = self.speaker_manager.name_to_id[speaker]
-                return torch.tensor(speaker_id, device=self.device), None
+                return torch.tensor([speaker_id], device=self.device), None
             speaker_exists = False
 
         if self.speaker_manager.encoder is not None and (speaker is not None or speaker_wav is not None):
@@ -530,6 +531,47 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
             "You need to pass either a speaker name or a reference audio file."
         )
         raise ValueError(msg)
+
+    def _get_speaker_conditioning(
+        self,
+        aux_input: dict[str, Any],
+        spk_emb_module_name: str = "speaker_embedding",
+        *,
+        normalize_d_vector: bool = True,
+        normalize_embedding: bool = True,
+        output_shape: Literal["BCT", "BTC"] = "BCT",
+    ) -> torch.Tensor | None:
+        """Return speaker conditioning vector for multi-speaker models.
+
+        Output shape: [b, h, 1]
+        """
+        sid = aux_input.get("speaker_ids")
+        g = aux_input.get("d_vectors")
+
+        if sid is not None and g is not None:
+            msg = "Cannot use both speaker_ids and d_vectors simultaneously. "
+            raise ValueError(msg)
+
+        if g is not None and normalize_d_vector:
+            g = F.normalize(g)
+        if get_from_config_or_model_args(self.config, "use_speaker_embedding") and sid is not None:
+            spk_emb_module = getattr(self, spk_emb_module_name, None)
+            if spk_emb_module is None:
+                msg = "Speaker embedding requested but no embedding module provided"
+                raise RuntimeError(msg)
+            g = spk_emb_module(sid)
+            assert g.ndim == 2
+            if normalize_embedding:
+                g = F.normalize(g)
+        if g is not None:
+            if output_shape == "BCT":
+                g = g.unsqueeze(-1)
+            elif output_shape == "BTC":
+                g = g.unsqueeze(1)
+            else:
+                msg = f"Invalid output shape `{output_shape}`. Use `BCT` or `BTC`."
+                raise ValueError(msg)
+        return g
 
     def _clone_voice(
         self, speaker_wav: str | os.PathLike[Any] | list[str | os.PathLike[Any]], **kwargs
@@ -580,7 +622,7 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
         _speaker_id, d_vector = self._get_speaker_id_or_dvector(speaker, speaker_wav, voice_dir)
         text_inputs = torch.as_tensor(text_inputs, dtype=torch.long, device=self.device).unsqueeze(0)
         if language_id is not None:
-            language_id = torch.tensor(language_id, device=self.device)
+            language_id = torch.tensor([language_id], device=self.device)
 
         if extra_aux_input is None:
             extra_aux_input = {}

--- a/TTS/tts/models/delightful_tts.py
+++ b/TTS/tts/models/delightful_tts.py
@@ -1080,51 +1080,49 @@ class DelightfulTTS(BaseTTSE2E):
         num_gpus: int,
         rank: int | None = None,
     ) -> "DataLoader":
-        if is_eval and not config.run_eval:
-            loader = None
-        else:
-            # init dataloader
-            dataset = ForwardTTSE2eDataset(
-                samples=samples,
-                ap=self.ap,
-                batch_group_size=0 if is_eval else config.batch_group_size * config.batch_size,
-                min_text_len=config.min_text_len,
-                max_text_len=config.max_text_len,
-                min_audio_len=config.min_audio_len,
-                max_audio_len=config.max_audio_len,
-                phoneme_cache_path=config.phoneme_cache_path,
-                precompute_num_workers=config.precompute_num_workers,
-                compute_f0=config.compute_f0,
-                f0_cache_path=config.f0_cache_path,
-                attn_prior_cache_path=config.attn_prior_cache_path if config.use_attn_priors else None,
-                tokenizer=self.tokenizer,
-                start_by_longest=config.start_by_longest,
-            )
+        # init dataloader
+        dataset = ForwardTTSE2eDataset(
+            samples=samples,
+            ap=self.ap,
+            batch_group_size=0 if is_eval else config.batch_group_size * config.batch_size,
+            min_text_len=config.min_text_len,
+            max_text_len=config.max_text_len,
+            min_audio_len=config.min_audio_len,
+            max_audio_len=config.max_audio_len,
+            phoneme_cache_path=config.phoneme_cache_path,
+            precompute_num_workers=config.precompute_num_workers,
+            compute_f0=config.compute_f0,
+            f0_cache_path=config.f0_cache_path,
+            attn_prior_cache_path=config.attn_prior_cache_path if config.use_attn_priors else None,
+            tokenizer=self.tokenizer,
+            start_by_longest=config.start_by_longest,
+        )
 
-            # wait all the DDP process to be ready
-            if num_gpus > 1:
-                dist.barrier()
+        # wait all the DDP process to be ready
+        if num_gpus > 1:
+            dist.barrier()
 
-            # sort input sequences ascendingly by length
-            dataset.preprocess_samples()
+        # sort input sequences ascendingly by length
+        dataset.preprocess_samples()
 
-            # get samplers
-            sampler = self.get_sampler(config, dataset, num_gpus)
+        # get samplers
+        sampler = self.get_sampler(config, dataset, num_gpus)
 
-            loader = DataLoader(
-                dataset,
-                batch_size=config.eval_batch_size if is_eval else config.batch_size,
-                shuffle=False,  # shuffle is done in the dataset.
-                drop_last=False,  # setting this False might cause issues in AMP training.
-                sampler=sampler,
-                collate_fn=dataset.collate_fn,
-                num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
-                pin_memory=True,
-            )
+        loader = DataLoader(
+            dataset,
+            batch_size=config.eval_batch_size if is_eval else config.batch_size,
+            shuffle=False,  # shuffle is done in the dataset.
+            drop_last=False,  # setting this False might cause issues in AMP training.
+            sampler=sampler,
+            collate_fn=dataset.collate_fn,
+            num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
+            pin_memory=True,
+        )
 
-            # get pitch mean and std
-            self.pitch_mean = dataset.f0_dataset.mean
-            self.pitch_std = dataset.f0_dataset.std
+        # get pitch mean and std
+        self.pitch_mean = dataset.f0_dataset.mean
+        self.pitch_std = dataset.f0_dataset.std
+
         return loader
 
     def get_criterion(self):

--- a/TTS/tts/models/delightful_tts.py
+++ b/TTS/tts/models/delightful_tts.py
@@ -16,6 +16,7 @@ from torch.utils.data.sampler import WeightedRandomSampler
 from trainer.torch import DistributedSampler, DistributedSamplerWrapper
 from trainer.trainer_utils import get_optimizer, get_scheduler
 
+from TTS.config.shared_configs import ModelArgs
 from TTS.tts.configs.shared_configs import BaseTTSConfig
 from TTS.tts.datasets.dataset import F0Dataset, TTSDataset, _parse_sample, get_attribute_balancer_weights
 from TTS.tts.layers.delightful_tts.acoustic_model import AcousticModel
@@ -317,7 +318,7 @@ class DelightfulTtsAudioConfig(Coqpit):
 
 
 @dataclass
-class DelightfulTtsArgs(Coqpit):
+class DelightfulTtsArgs(ModelArgs):
     num_chars: int = 100
     spec_segment_size: int = 32
     n_hidden_conformer_encoder: int = 512

--- a/TTS/tts/models/forward_tts.py
+++ b/TTS/tts/models/forward_tts.py
@@ -354,11 +354,6 @@ class ForwardTTS(BaseTTS):
             - x_mask: :math:`(B, 1, T_{en})`
             - g: :math:`(B, C)`
         """
-        if hasattr(self, "emb_g"):
-            g = g.type(torch.LongTensor).to(x.device)
-            g = self.emb_g(g)  # [B, C, 1]
-        if g is not None:
-            g = g.unsqueeze(-1)
         # [B, T, C]
         x_emb = self.emb(x)
         # encoder pass
@@ -520,19 +515,6 @@ class ForwardTTS(BaseTTS):
         alignment_soft = alignment_soft.squeeze(1).transpose(1, 2)
         return o_alignment_dur, alignment_soft, alignment_logprob, alignment_mas
 
-    def _set_speaker_input(self, aux_input: dict):
-        d_vectors = aux_input.get("d_vectors", None)
-        speaker_ids = aux_input.get("speaker_ids", None)
-
-        if d_vectors is not None and speaker_ids is not None:
-            raise ValueError("[!] Cannot use d-vectors and speaker-ids together.")
-
-        if speaker_ids is not None and not hasattr(self, "emb_g"):
-            raise ValueError("[!] Cannot use speaker-ids without enabling speaker embedding.")
-
-        g = speaker_ids if speaker_ids is not None else d_vectors
-        return g
-
     def forward(
         self,
         x: torch.LongTensor,
@@ -565,7 +547,7 @@ class ForwardTTS(BaseTTS):
             - g: :math:`[B, C]`
             - pitch: :math:`[B, 1, T]`
         """
-        g = self._set_speaker_input(aux_input)
+        g = self._get_speaker_conditioning(aux_input, "emb_g", normalize_d_vector=False, normalize_embedding=False)
         # compute sequence masks
         y_mask = torch.unsqueeze(sequence_mask(y_lengths, None), 1).float()
         x_mask = torch.unsqueeze(sequence_mask(x_lengths, x.shape[1]), 1).float()
@@ -639,7 +621,7 @@ class ForwardTTS(BaseTTS):
             - x_lengths: [B]
             - g: [B, C]
         """
-        g = self._set_speaker_input(aux_input)
+        g = self._get_speaker_conditioning(aux_input, "emb_g", normalize_d_vector=False, normalize_embedding=False)
         x_lengths = torch.tensor(x.shape[1:2]).to(x.device)
         x_mask = torch.unsqueeze(sequence_mask(x_lengths, x.shape[1]), 1).to(x.dtype).float()
         # encoder pass

--- a/TTS/tts/models/forward_tts.py
+++ b/TTS/tts/models/forward_tts.py
@@ -6,6 +6,7 @@ from coqpit import Coqpit
 from monotonic_alignment_search import maximum_path
 from torch import nn
 
+from TTS.config.shared_configs import ModelArgs
 from TTS.tts.layers.feed_forward.decoder import Decoder
 from TTS.tts.layers.feed_forward.encoder import Encoder
 from TTS.tts.layers.generic.aligner import AlignmentNetwork
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class ForwardTTSArgs(Coqpit):
+class ForwardTTSArgs(ModelArgs):
     """ForwardTTS Model arguments.
 
     Args:

--- a/TTS/tts/models/glow_tts.py
+++ b/TTS/tts/models/glow_tts.py
@@ -7,7 +7,6 @@ import torch
 from coqpit import Coqpit
 from monotonic_alignment_search import maximum_path
 from torch import nn
-from torch.nn import functional as F
 
 from TTS.tts.configs.glow_tts_config import GlowTTSConfig
 from TTS.tts.layers.glow_tts.decoder import Decoder
@@ -161,38 +160,7 @@ class GlowTTS(BaseTTS):
             if getattr(f, "set_ddi", False):
                 f.set_ddi(False)
 
-    def _set_speaker_input(self, aux_input: dict):
-        if aux_input is None:
-            d_vectors = None
-            speaker_ids = None
-        else:
-            d_vectors = aux_input.get("d_vectors", None)
-            speaker_ids = aux_input.get("speaker_ids", None)
-
-        if d_vectors is not None and speaker_ids is not None:
-            raise ValueError("[!] Cannot use d-vectors and speaker-ids together.")
-
-        if speaker_ids is not None and not hasattr(self, "emb_g"):
-            raise ValueError("[!] Cannot use speaker-ids without enabling speaker embedding.")
-
-        g = speaker_ids if speaker_ids is not None else d_vectors
-        return g
-
-    def _speaker_embedding(self, aux_input: dict) -> torch.Tensor | None:
-        g = self._set_speaker_input(aux_input)
-        # speaker embedding
-        if g is not None:
-            if hasattr(self, "emb_g"):
-                # use speaker embedding layer
-                if not g.size():  # if is a scalar
-                    g = g.unsqueeze(0)  # unsqueeze
-                g = F.normalize(self.emb_g(g)).unsqueeze(-1)  # [b, h, 1]
-            else:
-                # use d-vector
-                g = F.normalize(g).unsqueeze(-1)  # [b, h, 1]
-        return g
-
-    def forward(self, x, x_lengths, y, y_lengths=None, aux_input={"d_vectors": None, "speaker_ids": None}):  # pylint: disable=dangerous-default-value
+    def forward(self, x, x_lengths, y, y_lengths=None, aux_input: dict[str, Any] | None = None):
         """
         Args:
             x (torch.Tensor):
@@ -222,11 +190,13 @@ class GlowTTS(BaseTTS):
                 - durations_log: :math:`[B, T_en, 1]`
                 - total_durations_log: :math:`[B, T_en, 1]`
         """
+        if aux_input is None:
+            aux_input = {"d_vectors": None, "speaker_ids": None}
         # [B, T, C] -> [B, C, T]
         y = y.transpose(1, 2)
         y_max_length = y.size(2)
         # norm speaker embeddings
-        g = self._speaker_embedding(aux_input)
+        g = self._get_speaker_conditioning(aux_input, "emb_g")
         # embedding pass
         o_mean, o_log_scale, o_dur_log, x_mask = self.encoder(x, x_lengths, g=g)
         # drop redisual frames wrt num_squeeze and set y_lengths.
@@ -260,9 +230,7 @@ class GlowTTS(BaseTTS):
         return outputs
 
     @torch.inference_mode()
-    def inference_with_MAS(
-        self, x, x_lengths, y=None, y_lengths=None, aux_input={"d_vectors": None, "speaker_ids": None}
-    ):  # pylint: disable=dangerous-default-value
+    def inference_with_MAS(self, x, x_lengths, y=None, y_lengths=None, aux_input: dict[str, Any] | None = None):
         """
         It's similar to the teacher forcing in Tacotron.
         It was proposed in: https://arxiv.org/abs/2104.05557
@@ -274,10 +242,12 @@ class GlowTTS(BaseTTS):
             - y_lengths: :math:`B`
             - g: :math:`[B, C] or B`
         """
+        if aux_input is None:
+            aux_input = {"d_vectors": None, "speaker_ids": None}
         y = y.transpose(1, 2)
         y_max_length = y.size(2)
         # norm speaker embeddings
-        g = self._speaker_embedding(aux_input)
+        g = self._get_speaker_conditioning(aux_input, "emb_g")
         # embedding pass
         o_mean, o_log_scale, o_dur_log, x_mask = self.encoder(x, x_lengths, g=g)
         # drop redisual frames wrt num_squeeze and set y_lengths.
@@ -325,7 +295,7 @@ class GlowTTS(BaseTTS):
         """
         y = y.transpose(1, 2)
         y_max_length = y.size(2)
-        g = self._speaker_embedding(aux_input)
+        g = self._get_speaker_conditioning(aux_input, "emb_g")
         y_mask = torch.unsqueeze(sequence_mask(y_lengths, y_max_length), 1).to(y.dtype)
         # decoder pass
         z, logdet = self.decoder(y, y_mask, g=g, reverse=False)
@@ -337,9 +307,11 @@ class GlowTTS(BaseTTS):
         return outputs
 
     @torch.inference_mode()
-    def inference(self, x, aux_input={"x_lengths": None, "d_vectors": None, "speaker_ids": None}):  # pylint: disable=dangerous-default-value
+    def inference(self, x, aux_input: dict[str, Any] | None = None):
+        if aux_input is None:
+            aux_input = {"x_lengths": None, "d_vectors": None, "speaker_ids": None}
         x_lengths = aux_input["x_lengths"]
-        g = self._speaker_embedding(aux_input)
+        g = self._get_speaker_conditioning(aux_input, "emb_g")
         # embedding pass
         o_mean, o_log_scale, o_dur_log, x_mask = self.encoder(x, x_lengths, g=g)
         # compute output durations

--- a/TTS/tts/models/tacotron.py
+++ b/TTS/tts/models/tacotron.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import torch
 from torch import nn
 from trainer.trainer_utils import get_optimizer, get_scheduler
@@ -132,9 +134,7 @@ class Tacotron(BaseTacotron):
                 self.max_decoder_steps,
             )
 
-    def forward(  # pylint: disable=dangerous-default-value
-        self, text, text_lengths, mel_specs=None, mel_lengths=None, aux_input={"speaker_ids": None, "d_vectors": None}
-    ):
+    def forward(self, text, text_lengths, mel_specs=None, mel_lengths=None, aux_input: dict[str, Any] | None = None):
         """
         Shapes:
             text: [B, T_in]
@@ -143,6 +143,8 @@ class Tacotron(BaseTacotron):
             mel_lengths: [B]
             aux_input: 'speaker_ids': [B, 1] and  'd_vectors':[B, C]
         """
+        if aux_input is None:
+            aux_input = {"speaker_ids": None, "d_vectors": None}
         aux_input = self._format_aux_input(aux_input)
         outputs = {"alignments_backward": None, "decoder_outputs_backward": None}
         inputs = self.embedding(text)
@@ -155,14 +157,11 @@ class Tacotron(BaseTacotron):
         if self.gst and self.use_gst:
             # B x gst_dim
             encoder_outputs = self.compute_gst(encoder_outputs, mel_specs)
-        # speaker embedding
-        if self.use_speaker_embedding or self.use_d_vector_file:
-            if not self.use_d_vector_file:
-                # B x 1 x speaker_embed_dim
-                embedded_speakers = self.speaker_embedding(aux_input["speaker_ids"])[:, None]
-            else:
-                # B x 1 x speaker_embed_dim
-                embedded_speakers = torch.unsqueeze(aux_input["d_vectors"], 1)
+        # speaker embedding: B x 1 x speaker_embed_dim
+        embedded_speakers = self._get_speaker_conditioning(
+            aux_input, "speaker_embedding", normalize_d_vector=False, normalize_embedding=False, output_shape="BTC"
+        )
+        if embedded_speakers is not None:
             encoder_outputs = self._concat_speaker_embedding(encoder_outputs, embedded_speakers)
         # Capacitron
         if self.capacitron_vae and self.use_capacitron_vae:
@@ -245,17 +244,13 @@ class Tacotron(BaseTacotron):
                 ),
             )
         if self.num_speakers > 1:
-            if not self.use_d_vector_file:
-                # B x 1 x speaker_embed_dim
-                embedded_speakers = self.speaker_embedding(aux_input["speaker_ids"])
-                # reshape embedded_speakers
-                if embedded_speakers.ndim == 1:
-                    embedded_speakers = embedded_speakers[None, None, :]
-                elif embedded_speakers.ndim == 2:
-                    embedded_speakers = embedded_speakers[None, :]
-            else:
-                # B x 1 x speaker_embed_dim
-                embedded_speakers = torch.unsqueeze(aux_input["d_vectors"], 1)
+            embedded_speakers = self._get_speaker_conditioning(
+                aux_input,
+                "speaker_embedding",
+                normalize_d_vector=False,
+                normalize_embedding=False,
+                output_shape="BTC",
+            )
             encoder_outputs = self._concat_speaker_embedding(encoder_outputs, embedded_speakers)
         decoder_outputs, alignments, stop_tokens = self.decoder.inference(encoder_outputs)
         postnet_outputs = self.postnet(decoder_outputs)

--- a/TTS/tts/models/tacotron2.py
+++ b/TTS/tts/models/tacotron2.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import torch
 from torch import nn
 from trainer.trainer_utils import get_optimizer, get_scheduler
@@ -149,7 +151,7 @@ class Tacotron2(BaseTacotron):
         return mel_outputs, mel_outputs_postnet, alignments
 
     def forward(  # pylint: disable=dangerous-default-value
-        self, text, text_lengths, mel_specs=None, mel_lengths=None, aux_input={"speaker_ids": None, "d_vectors": None}
+        self, text, text_lengths, mel_specs=None, mel_lengths=None, aux_input: dict[str, Any] | None = None
     ):
         """Forward pass for training with Teacher Forcing.
 
@@ -160,6 +162,8 @@ class Tacotron2(BaseTacotron):
             mel_lengths: :math:`[B]`
             aux_input: 'speaker_ids': :math:`[B, 1]` and  'd_vectors': :math:`[B, C]`
         """
+        if aux_input is None:
+            aux_input = {"speaker_ids": None, "d_vectors": None}
         aux_input = self._format_aux_input(aux_input)
         outputs = {"alignments_backward": None, "decoder_outputs_backward": None}
         # compute mask for padding
@@ -173,13 +177,10 @@ class Tacotron2(BaseTacotron):
             # B x gst_dim
             encoder_outputs = self.compute_gst(encoder_outputs, mel_specs)
 
-        if self.use_speaker_embedding or self.use_d_vector_file:
-            if not self.use_d_vector_file:
-                # B x 1 x speaker_embed_dim
-                embedded_speakers = self.speaker_embedding(aux_input["speaker_ids"])[:, None]
-            else:
-                # B x 1 x speaker_embed_dim
-                embedded_speakers = torch.unsqueeze(aux_input["d_vectors"], 1)
+        embedded_speakers = self._get_speaker_conditioning(
+            aux_input, "speaker_embedding", normalize_d_vector=False, normalize_embedding=False, output_shape="BTC"
+        )
+        if embedded_speakers is not None:
             encoder_outputs = self._concat_speaker_embedding(encoder_outputs, embedded_speakers)
 
         # capacitron
@@ -274,16 +275,13 @@ class Tacotron2(BaseTacotron):
             )
 
         if self.num_speakers > 1:
-            if not self.use_d_vector_file:
-                embedded_speakers = self.speaker_embedding(aux_input["speaker_ids"])[None]
-                # reshape embedded_speakers
-                if embedded_speakers.ndim == 1:
-                    embedded_speakers = embedded_speakers[None, None, :]
-                elif embedded_speakers.ndim == 2:
-                    embedded_speakers = embedded_speakers[None, :]
-            else:
-                embedded_speakers = aux_input["d_vectors"]
-
+            embedded_speakers = self._get_speaker_conditioning(
+                aux_input,
+                "speaker_embedding",
+                normalize_d_vector=False,
+                normalize_embedding=False,
+                output_shape="BTC",
+            )
             encoder_outputs = self._concat_speaker_embedding(encoder_outputs, embedded_speakers)
 
         decoder_outputs, alignments, stop_tokens = self.decoder.inference(encoder_outputs)

--- a/TTS/tts/models/tortoise.py
+++ b/TTS/tts/models/tortoise.py
@@ -11,6 +11,7 @@ import torchaudio
 from coqpit import Coqpit
 from tqdm import tqdm
 
+from TTS.config.shared_configs import ModelArgs
 from TTS.tts.configs.shared_configs import BaseTTSConfig
 from TTS.tts.layers.tortoise.arch_utils import TorchMelSpectrogram
 from TTS.tts.layers.tortoise.audio_utils import (
@@ -218,7 +219,7 @@ class TortoiseAudioConfig(Coqpit):
 
 
 @dataclass
-class TortoiseArgs(Coqpit):
+class TortoiseArgs(ModelArgs):
     """A dataclass to represent Tortoise model arguments that define the model structure.
 
     Args:

--- a/TTS/tts/models/vits.py
+++ b/TTS/tts/models/vits.py
@@ -1344,61 +1344,58 @@ class Vits(BaseTTS):
         num_gpus: int,
         rank: int | None = None,
     ) -> "DataLoader":
-        if is_eval and not config.run_eval:
-            loader = None
-        else:
-            # init dataloader
-            dataset = VitsDataset(
-                model_args=self.args,
-                samples=samples,
-                batch_group_size=0 if is_eval else config.batch_group_size * config.batch_size,
-                min_text_len=config.min_text_len,
-                max_text_len=config.max_text_len,
-                min_audio_len=config.min_audio_len,
-                max_audio_len=config.max_audio_len,
-                phoneme_cache_path=config.phoneme_cache_path,
-                precompute_num_workers=config.precompute_num_workers,
-                tokenizer=self.tokenizer,
-                start_by_longest=config.start_by_longest,
+        # init dataloader
+        dataset = VitsDataset(
+            model_args=self.args,
+            samples=samples,
+            batch_group_size=0 if is_eval else config.batch_group_size * config.batch_size,
+            min_text_len=config.min_text_len,
+            max_text_len=config.max_text_len,
+            min_audio_len=config.min_audio_len,
+            max_audio_len=config.max_audio_len,
+            phoneme_cache_path=config.phoneme_cache_path,
+            precompute_num_workers=config.precompute_num_workers,
+            tokenizer=self.tokenizer,
+            start_by_longest=config.start_by_longest,
+        )
+
+        # wait all the DDP process to be ready
+        if num_gpus > 1:
+            dist.barrier()
+
+        # sort input sequences from short to long
+        dataset.preprocess_samples()
+
+        # get samplers
+        sampler = self.get_sampler(config, dataset, num_gpus)
+        if sampler is None:
+            loader = DataLoader(
+                dataset,
+                batch_size=config.eval_batch_size if is_eval else config.batch_size,
+                shuffle=False,  # shuffle is done in the dataset.
+                collate_fn=dataset.collate_fn,
+                drop_last=False,  # setting this False might cause issues in AMP training.
+                num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
+                pin_memory=False,
             )
-
-            # wait all the DDP process to be ready
+        else:
             if num_gpus > 1:
-                dist.barrier()
-
-            # sort input sequences from short to long
-            dataset.preprocess_samples()
-
-            # get samplers
-            sampler = self.get_sampler(config, dataset, num_gpus)
-            if sampler is None:
                 loader = DataLoader(
                     dataset,
+                    sampler=sampler,
                     batch_size=config.eval_batch_size if is_eval else config.batch_size,
-                    shuffle=False,  # shuffle is done in the dataset.
                     collate_fn=dataset.collate_fn,
-                    drop_last=False,  # setting this False might cause issues in AMP training.
                     num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
                     pin_memory=False,
                 )
             else:
-                if num_gpus > 1:
-                    loader = DataLoader(
-                        dataset,
-                        sampler=sampler,
-                        batch_size=config.eval_batch_size if is_eval else config.batch_size,
-                        collate_fn=dataset.collate_fn,
-                        num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
-                        pin_memory=False,
-                    )
-                else:
-                    loader = DataLoader(
-                        dataset,
-                        batch_sampler=sampler,
-                        collate_fn=dataset.collate_fn,
-                        num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
-                        pin_memory=False,
-                    )
+                loader = DataLoader(
+                    dataset,
+                    batch_sampler=sampler,
+                    collate_fn=dataset.collate_fn,
+                    num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
+                    pin_memory=False,
+                )
         return loader
 
     def get_optimizer(self) -> list:

--- a/TTS/tts/models/vits.py
+++ b/TTS/tts/models/vits.py
@@ -705,42 +705,6 @@ class Vits(BaseTTS):
             for param in self.waveform_decoder.parameters():
                 param.requires_grad = False
 
-    @staticmethod
-    def _set_cond_input(aux_input: dict):
-        """Set the speaker conditioning input based on the multi-speaker mode."""
-        sid, g, lid, durations = None, None, None, None
-        if "speaker_ids" in aux_input and aux_input["speaker_ids"] is not None:
-            sid = aux_input["speaker_ids"]
-            if sid.ndim == 0:
-                sid = sid.unsqueeze_(0)
-        if "d_vectors" in aux_input and aux_input["d_vectors"] is not None:
-            g = F.normalize(aux_input["d_vectors"]).unsqueeze(-1)
-            if g.ndim == 2:
-                g = g.unsqueeze_(0)
-
-        if "language_ids" in aux_input and aux_input["language_ids"] is not None:
-            lid = aux_input["language_ids"]
-            if lid.ndim == 0:
-                lid = lid.unsqueeze_(0)
-
-        if "durations" in aux_input and aux_input["durations"] is not None:
-            durations = aux_input["durations"]
-
-        return sid, g, lid, durations
-
-    def _set_speaker_input(self, aux_input: dict):
-        d_vectors = aux_input.get("d_vectors", None)
-        speaker_ids = aux_input.get("speaker_ids", None)
-
-        if d_vectors is not None and speaker_ids is not None:
-            raise ValueError("[!] Cannot use d-vectors and speaker-ids together.")
-
-        if speaker_ids is not None and not hasattr(self, "emb_g"):
-            raise ValueError("[!] Cannot use speaker-ids without enabling speaker embedding.")
-
-        g = speaker_ids if speaker_ids is not None else d_vectors
-        return g
-
     def forward_mas(self, outputs, z_p, m_p, logs_p, x, x_mask, y_mask, g, lang_emb):
         # find the alignment path
         attn_mask = torch.unsqueeze(x_mask, -1) * torch.unsqueeze(y_mask, 2)
@@ -840,13 +804,11 @@ class Vits(BaseTTS):
             - syn_spk_emb: :math:`[B, 1, speaker_encoder.proj_dim]`
         """
         outputs = {}
-        sid, g, lid, _ = self._set_cond_input(aux_input)
-        # speaker embedding
-        if self.args.use_speaker_embedding and sid is not None:
-            g = self.emb_g(sid).unsqueeze(-1)  # [b, h, 1]
+        g = self._get_speaker_conditioning(aux_input, "emb_g", normalize_embedding=False)
 
         # language embedding
         lang_emb = None
+        lid = aux_input.get("language_ids")
         if self.args.use_language_embedding and lid is not None:
             lang_emb = self.emb_l(lid).unsqueeze(-1)
 
@@ -944,20 +906,18 @@ class Vits(BaseTTS):
             - m_p: :math:`[B, C, T_dec]`
             - logs_p: :math:`[B, C, T_dec]`
         """
-        sid, g, lid, durations = self._set_cond_input(aux_input)
+        g = self._get_speaker_conditioning(aux_input, "emb_g", normalize_embedding=False)
         x_lengths = self._set_x_lengths(x, aux_input)
-
-        # speaker embedding
-        if self.args.use_speaker_embedding and sid is not None:
-            g = self.emb_g(sid).unsqueeze(-1)
 
         # language embedding
         lang_emb = None
+        lid = aux_input.get("language_ids")
         if self.args.use_language_embedding and lid is not None:
             lang_emb = self.emb_l(lid).unsqueeze(-1)
 
         x, m_p, logs_p, x_mask = self.text_encoder(x, x_lengths, lang_emb=lang_emb)
 
+        durations = aux_input.get("durations")
         if durations is None:
             if self.args.use_sdp:
                 logw = self.duration_predictor(

--- a/TTS/tts/models/vits.py
+++ b/TTS/tts/models/vits.py
@@ -20,6 +20,7 @@ from trainer.io import load_fsspec
 from trainer.torch import DistributedSampler, DistributedSamplerWrapper
 from trainer.trainer_utils import get_optimizer, get_scheduler
 
+from TTS.config.shared_configs import ModelArgs
 from TTS.tts.configs.shared_configs import CharactersConfig
 from TTS.tts.datasets.dataset import TTSDataset, _parse_sample, get_attribute_balancer_weights
 from TTS.tts.layers.glow_tts.duration_predictor import DurationPredictor
@@ -205,7 +206,7 @@ class VitsDataset(TTSDataset):
 
 
 @dataclass
-class VitsArgs(Coqpit):
+class VitsArgs(ModelArgs):
     """VITS model arguments.
 
     Args:

--- a/TTS/tts/models/vits.py
+++ b/TTS/tts/models/vits.py
@@ -630,7 +630,7 @@ class Vits(BaseTTS):
             config (Coqpit): Model configuration.
         """
         if self.args.language_ids_file is not None:
-            self.language_manager = LanguageManager(language_ids_file_path=config.language_ids_file)
+            self.language_manager = LanguageManager(language_ids_file_path=self.args.language_ids_file)
 
         if self.args.use_language_embedding and self.language_manager:
             logger.info("Initialization of language-embedding layers.")

--- a/TTS/tts/models/xtts.py
+++ b/TTS/tts/models/xtts.py
@@ -11,6 +11,7 @@ import torchaudio
 from coqpit import Coqpit
 from trainer.io import load_fsspec
 
+from TTS.config.shared_configs import ModelArgs
 from TTS.tts.configs.shared_configs import BaseTTSConfig
 from TTS.tts.layers.xtts.gpt import GPT
 from TTS.tts.layers.xtts.hifigan_decoder import HifiDecoder
@@ -116,7 +117,7 @@ class XttsAudioConfig(Coqpit):
 
 
 @dataclass
-class XttsArgs(Coqpit):
+class XttsArgs(ModelArgs):
     """A dataclass to represent XTTS model arguments that define the model structure.
 
     Args:

--- a/TTS/tts/utils/languages.py
+++ b/TTS/tts/utils/languages.py
@@ -5,7 +5,6 @@ import numpy as np
 import torch
 from coqpit import Coqpit
 
-from TTS.config import get_from_config_or_model_args
 from TTS.tts.utils.managers import BaseIDManager
 
 
@@ -90,9 +89,9 @@ class LanguageManager(BaseIDManager):
         Args:
             config (Coqpit): Coqpit config.
         """
-        if get_from_config_or_model_args(config, "use_language_embedding"):
-            if config.get("language_ids_file", None):
-                return LanguageManager(language_ids_file_path=config.language_ids_file)
+        if config.model_args.get("use_language_embedding"):
+            if config.model_args.get("language_ids_file"):
+                return LanguageManager(language_ids_file_path=config.model_args.language_ids_file)
             # Fall back to parse language IDs from the config
             return LanguageManager(config=config)
         return None

--- a/TTS/utils/manage.py
+++ b/TTS/utils/manage.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import re
@@ -9,7 +8,6 @@ from pathlib import Path
 from shutil import copyfile, rmtree
 from typing import Any, TypedDict
 
-import fsspec
 import requests
 from tqdm import tqdm
 from trainer.io import get_user_data_dir
@@ -373,22 +371,6 @@ class ModelManager:
             checkpoints[0].rename(checkpoints[0].parent / "model.pth")
         self.print_model_license(model_item=model_item)
 
-    def check_if_configs_are_equal(self, model_name: str, model_item: ModelItem, output_path: Path) -> None:
-        with fsspec.open(self._find_files(output_path)[1], "r", encoding="utf-8") as f:
-            config_local = json.load(f)
-        remote_url = None
-        for url in model_item["hf_url"]:
-            if "config.json" in url:
-                remote_url = url
-                break
-
-        with fsspec.open(remote_url, "r", encoding="utf-8") as f:
-            config_remote = json.load(f)
-
-        if not config_local == config_remote:
-            logger.info("%s is already downloaded however it has been changed. Redownloading it...", model_name)
-            self.create_dir_and_download_model(model_name, model_item, output_path)
-
     def download_model(self, model_name: str) -> tuple[Path, Path | None, ModelItem]:
         """Download model files given the full model name.
         Model name is in the format
@@ -419,15 +401,7 @@ class ModelManager:
                 else:
                     logger.info("%s has been updated, clearing model cache...", model_name)
                     self.create_dir_and_download_model(model_name, model_item, output_path)
-            # if the configs are different, redownload it
-            # ToDo: we need a better way to handle it
-            if "xtts" in model_name:
-                try:
-                    self.check_if_configs_are_equal(model_name, model_item, output_path)
-                except:
-                    pass
-            else:
-                logger.info("%s is already downloaded.", model_name)
+            logger.info("%s is already downloaded.", model_name)
         else:
             self.create_dir_and_download_model(model_name, model_item, output_path)
 

--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -235,9 +235,7 @@ class Synthesizer(nn.Module):
 
     def _set_speaker_encoder_paths_from_tts_config(self):
         """Set the encoder paths from the tts model config for models with speaker encoders."""
-        if self.tts_config.model_args is not None and hasattr(
-            self.tts_config.model_args, "speaker_encoder_config_path"
-        ):
+        if self.tts_config.model_args.get("speaker_encoder_config_path"):
             self.encoder_checkpoint = self.tts_config.model_args.speaker_encoder_model_path
             self.encoder_config = self.tts_config.model_args.speaker_encoder_config_path
 

--- a/TTS/vc/configs/freevc_config.py
+++ b/TTS/vc/configs/freevc_config.py
@@ -219,12 +219,6 @@ class FreeVCConfig(BaseVCConfig):
         test_sentences (List[List]):
             List of sentences with speaker and language information to be used for testing.
 
-        language_ids_file (str):
-            Path to the language ids file.
-
-        use_language_embedding (bool):
-            If true, language embedding is used. Defaults to `False`.
-
     Note:
         Check :class:`TTS.tts.configs.shared_configs.BaseVCConfig` for the inherited parameters.
 

--- a/TTS/vc/configs/freevc_config.py
+++ b/TTS/vc/configs/freevc_config.py
@@ -252,17 +252,6 @@ class FreeVCConfig(BaseVCConfig):
     r: int = 1  # DO NOT CHANGE
     add_blank: bool = True
 
-    # multi-speaker settings
-    # use speaker embedding layer
-    num_speakers: int = 0
-    speakers_file: str = None
-    speaker_embedding_channels: int = 256
-
-    # use d-vectors
-    use_d_vector_file: bool = False
-    d_vector_file: list[str] = None
-    d_vector_dim: int = None
-
     def __post_init__(self):
         for key, val in self.model_args.items():
             if hasattr(self, key):

--- a/TTS/vc/configs/freevc_config.py
+++ b/TTS/vc/configs/freevc_config.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 
 from coqpit import Coqpit
 
+from TTS.config.shared_configs import ModelArgs
 from TTS.vc.configs.shared_configs import BaseVCConfig
 
 
@@ -50,7 +51,7 @@ class FreeVCAudioConfig(Coqpit):
 
 
 @dataclass
-class FreeVCArgs(Coqpit):
+class FreeVCArgs(ModelArgs):
     """FreeVC model arguments
 
     Args:

--- a/TTS/vc/configs/knnvc_config.py
+++ b/TTS/vc/configs/knnvc_config.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass, field
 
-from coqpit import Coqpit
-
-from TTS.config.shared_configs import BaseAudioConfig
+from TTS.config.shared_configs import BaseAudioConfig, ModelArgs
 from TTS.vc.configs.shared_configs import BaseVCConfig
 
 
@@ -19,7 +17,7 @@ class KNNVCAudioConfig(BaseAudioConfig):
 
 
 @dataclass
-class KNNVCArgs(Coqpit):
+class KNNVCArgs(ModelArgs):
     """Model arguments.
 
     Args:

--- a/TTS/vc/configs/openvoice_config.py
+++ b/TTS/vc/configs/openvoice_config.py
@@ -184,17 +184,6 @@ class OpenVoiceConfig(BaseVCConfig):
     r: int = 1  # DO NOT CHANGE
     add_blank: bool = True
 
-    # multi-speaker settings
-    # use speaker embedding layer
-    num_speakers: int = 0
-    speakers_file: str | None = None
-    speaker_embedding_channels: int = 256
-
-    # use d-vectors
-    use_d_vector_file: bool = False
-    d_vector_file: list[str] | None = None
-    d_vector_dim: int | None = None
-
     def __post_init__(self) -> None:
         for key, val in self.model_args.items():
             if hasattr(self, key):

--- a/TTS/vc/configs/openvoice_config.py
+++ b/TTS/vc/configs/openvoice_config.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 
 from coqpit import Coqpit
 
+from TTS.config.shared_configs import ModelArgs
 from TTS.vc.configs.shared_configs import BaseVCConfig
 
 
@@ -34,7 +35,7 @@ class OpenVoiceAudioConfig(Coqpit):
 
 
 @dataclass
-class OpenVoiceArgs(Coqpit):
+class OpenVoiceArgs(ModelArgs):
     """OpenVoice model arguments.
 
     zero_g (bool):

--- a/TTS/vc/configs/shared_configs.py
+++ b/TTS/vc/configs/shared_configs.py
@@ -93,18 +93,6 @@ class BaseVCConfig(BaseTrainingConfig):
             If between 0.0 and 1.0 represents the proportion of the dataset to include in the evaluation set.
             If > 1, represents the absolute number of evaluation samples. Defaults to 0.01 (1%).
 
-        use_speaker_weighted_sampler (bool):
-            Enable / Disable the batch balancer by speaker. Defaults to ```False```.
-
-        speaker_weighted_sampler_alpha (float):
-            Number that control the influence of the speaker sampler weights. Defaults to ```1.0```.
-
-        use_language_weighted_sampler (bool):
-            Enable / Disable the batch balancer by language. Defaults to ```False```.
-
-        language_weighted_sampler_alpha (float):
-            Number that control the influence of the language sampler weights. Defaults to ```1.0```.
-
         use_length_weighted_sampler (bool):
             Enable / Disable the batch balancer by audio length. If enabled the dataset will be divided
             into 10 buckets considering the min and max audio of the dataset. The sampler weights will be
@@ -146,9 +134,5 @@ class BaseVCConfig(BaseTrainingConfig):
     eval_split_max_size: int | None = None
     eval_split_size: float = 0.01
     # weighted samplers
-    use_speaker_weighted_sampler: bool = False
-    speaker_weighted_sampler_alpha: float = 1.0
-    use_language_weighted_sampler: bool = False
-    language_weighted_sampler_alpha: float = 1.0
     use_length_weighted_sampler: bool = False
     length_weighted_sampler_alpha: float = 1.0

--- a/TTS/vc/configs/shared_configs.py
+++ b/TTS/vc/configs/shared_configs.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 
 from TTS.config import BaseAudioConfig, BaseDatasetConfig, BaseTrainingConfig
+from TTS.config.shared_configs import ModelArgs
 
 
 @dataclass
@@ -114,6 +115,7 @@ class BaseVCConfig(BaseTrainingConfig):
     """
 
     audio: BaseAudioConfig = field(default_factory=BaseAudioConfig)
+    model_args: ModelArgs = field(default_factory=ModelArgs)
     # training params
     batch_group_size: int = 0
     loss_masking: bool = None

--- a/TTS/vc/models/base_vc.py
+++ b/TTS/vc/models/base_vc.py
@@ -1,24 +1,18 @@
 import logging
-import os
-import random
 from typing import Any
 
 import torch
 import torch.distributed as dist
 from coqpit import Coqpit
-from torch import nn
 from torch.utils.data import DataLoader
 from torch.utils.data.sampler import WeightedRandomSampler
 from trainer.torch import DistributedSampler, DistributedSamplerWrapper
 from trainer.trainer import Trainer
 
-from TTS.config import get_from_config_or_model_args
 from TTS.config.shared_configs import ModelArgs
 from TTS.model import BaseTrainerModel
 from TTS.tts.datasets.dataset import TTSDataset
 from TTS.tts.utils.data import get_length_balancer_weights
-from TTS.tts.utils.languages import get_language_balancer_weights
-from TTS.tts.utils.speakers import SpeakerManager, get_speaker_balancer_weights
 from TTS.utils.audio.processor import AudioProcessor
 from TTS.vc.configs.shared_configs import BaseVCConfig
 
@@ -35,16 +29,10 @@ class BaseVC(BaseTrainerModel):
 
     MODEL_TYPE = "vc"
 
-    def __init__(
-        self,
-        config: Coqpit,
-        ap: AudioProcessor | None = None,
-        speaker_manager: SpeakerManager | None = None,
-    ) -> None:
+    def __init__(self, config: Coqpit, ap: AudioProcessor | None = None) -> None:
         super().__init__()
         self.config = config
         self.ap = ap
-        self.speaker_manager = speaker_manager
         self._set_model_args()
 
     def _set_model_args(self) -> None:
@@ -66,84 +54,6 @@ class BaseVC(BaseTrainerModel):
         else:
             raise ValueError("config must be either a *Config or *Args")
 
-    def init_multispeaker(self, config: Coqpit) -> None:
-        """Set up for multi-speaker use.
-
-        Initialize a speaker embedding layer if needed and define the expected
-        embedding channel size for defining ``in_channels`` size of the connected layers.
-
-        This implementation yields 3 possible outcomes:
-
-        1. If ``config.use_speaker_embedding`` and ``config.use_d_vector_file`` are False, do nothing.
-        2. If ``config.use_d_vector_file`` is True, set expected embedding channel size to ``config.d_vector_dim`` or 512.
-        3. If ``config.use_speaker_embedding``, initialize a speaker embedding
-           layer with channel size of ``config.d_vector_dim`` or 512.
-
-        You can override this function for new models.
-
-        Args:
-            config (Coqpit): Model configuration.
-        """
-        # set number of speakers
-        if self.speaker_manager is not None:
-            self.num_speakers = self.speaker_manager.num_speakers
-        elif hasattr(config, "num_speakers"):
-            self.num_speakers = config.num_speakers
-
-        # set ultimate speaker embedding size
-        if config.use_speaker_embedding or config.use_d_vector_file:
-            self.embedded_speaker_dim = (
-                config.d_vector_dim if "d_vector_dim" in config and config.d_vector_dim is not None else 512
-            )
-        # init speaker embedding layer
-        if config.use_speaker_embedding and not config.use_d_vector_file:
-            logger.info("Init speaker_embedding layer.")
-            self.speaker_embedding = nn.Embedding(self.num_speakers, self.embedded_speaker_dim)
-            self.speaker_embedding.weight.data.normal_(0, 0.3)
-
-    def get_aux_input_from_test_sentences(self, sentence_info: str | list[str]) -> dict[str, Any]:
-        if hasattr(self.config, "model_args"):
-            config = self.config.model_args
-        else:
-            config = self.config
-
-        # extract speaker and language info
-        text, speaker_name, style_wav, language_name = None, None, None, None
-
-        if isinstance(sentence_info, list):
-            if len(sentence_info) == 1:
-                text = sentence_info[0]
-            elif len(sentence_info) == 2:
-                text, speaker_name = sentence_info
-            elif len(sentence_info) == 3:
-                text, speaker_name, style_wav = sentence_info
-            elif len(sentence_info) == 4:
-                text, speaker_name, style_wav, language_name = sentence_info
-        else:
-            text = sentence_info
-
-        # get speaker  id/d_vector
-        speaker_id, d_vector, language_id = None, None, None
-        if self.speaker_manager is not None:
-            if config.use_d_vector_file:
-                if speaker_name is None:
-                    d_vector = self.speaker_manager.get_random_embedding()
-                else:
-                    d_vector = self.speaker_manager.get_mean_embedding(speaker_name)
-            elif config.use_speaker_embedding:
-                if speaker_name is None:
-                    speaker_id = self.speaker_manager.get_random_id()
-                else:
-                    speaker_id = self.speaker_manager.name_to_id[speaker_name]
-
-        return {
-            "text": text,
-            "speaker_id": speaker_id,
-            "style_wav": style_wav,
-            "d_vector": d_vector,
-            "language_id": language_id,
-        }
-
     def format_batch(self, batch: dict[str, Any]) -> dict[str, Any]:
         """Generic batch formatting for ``VCDataset``.
 
@@ -158,14 +68,12 @@ class BaseVC(BaseTrainerModel):
         # setup input batch
         text_input = batch["token_id"]
         text_lengths = batch["token_id_lengths"]
-        speaker_names = batch["speaker_names"]
         linear_input = batch["linear"]
         mel_input = batch["mel"]
         mel_lengths = batch["mel_lengths"]
         stop_targets = batch["stop_targets"]
         item_idx = batch["item_idxs"]
         d_vectors = batch["d_vectors"]
-        speaker_ids = batch["speaker_ids"]
         attn_mask = batch["attns"]
         waveform = batch["waveform"]
         pitch = batch["pitch"]
@@ -202,7 +110,6 @@ class BaseVC(BaseTrainerModel):
         return {
             "text_input": text_input,
             "text_lengths": text_lengths,
-            "speaker_names": speaker_names,
             "mel_input": mel_input,
             "mel_lengths": mel_lengths,
             "linear_input": linear_input,
@@ -210,7 +117,6 @@ class BaseVC(BaseTrainerModel):
             "stop_target_lengths": stop_target_lengths,
             "attn_mask": attn_mask,
             "durations": durations,
-            "speaker_ids": speaker_ids,
             "d_vectors": d_vectors,
             "max_text_length": float(max_text_length),
             "max_spec_length": float(max_spec_length),
@@ -224,19 +130,6 @@ class BaseVC(BaseTrainerModel):
     def get_sampler(self, config: Coqpit, dataset: TTSDataset, num_gpus: int = 1):
         weights = None
         data_items = dataset.samples
-
-        if getattr(config, "use_language_weighted_sampler", False):
-            alpha = getattr(config, "language_weighted_sampler_alpha", 1.0)
-            logger.info("Using Language weighted sampler with alpha: %.2f", alpha)
-            weights = get_language_balancer_weights(data_items) * alpha
-
-        if getattr(config, "use_speaker_weighted_sampler", False):
-            alpha = getattr(config, "speaker_weighted_sampler_alpha", 1.0)
-            logger.info("Using Speaker weighted sampler with alpha: %.2f", alpha)
-            if weights is not None:
-                weights += get_speaker_balancer_weights(data_items) * alpha
-            else:
-                weights = get_speaker_balancer_weights(data_items) * alpha
 
         if getattr(config, "use_length_weighted_sampler", False):
             alpha = getattr(config, "length_weighted_sampler_alpha", 1.0)
@@ -269,23 +162,6 @@ class BaseVC(BaseTrainerModel):
         num_gpus: int,
         rank: int | None = None,
     ) -> "DataLoader":
-        # setup multi-speaker attributes
-        if self.speaker_manager is not None:
-            speaker_id_mapping = (
-                self.speaker_manager.name_to_id
-                if get_from_config_or_model_args(config, "use_speaker_embedding")
-                else None
-            )
-            d_vector_mapping = (
-                self.speaker_manager.embeddings if get_from_config_or_model_args(config, "use_d_vector_file") else None
-            )
-            config.use_d_vector_file = get_from_config_or_model_args(config, "use_d_vector_file", False)
-        else:
-            speaker_id_mapping = None
-            d_vector_mapping = None
-
-        language_id_mapping = None
-
         # init dataloader
         dataset = TTSDataset(
             outputs_per_step=config.r if "r" in config else 1,
@@ -305,11 +181,8 @@ class BaseVC(BaseTrainerModel):
             phoneme_cache_path=config.phoneme_cache_path,
             precompute_num_workers=config.precompute_num_workers,
             use_noise_augment=False if is_eval else config.use_noise_augment,
-            speaker_id_mapping=speaker_id_mapping,
-            d_vector_mapping=d_vector_mapping if config.use_d_vector_file else None,
             tokenizer=None,
             start_by_longest=config.start_by_longest,
-            language_id_mapping=language_id_mapping,
         )
 
         # wait all the DDP process to be ready
@@ -333,25 +206,6 @@ class BaseVC(BaseTrainerModel):
             pin_memory=False,
         )
 
-    def _get_test_aux_input(
-        self,
-    ) -> dict[str, Any]:
-        d_vector = None
-        if self.speaker_manager is not None and self.config.use_d_vector_file:
-            d_vector = [self.speaker_manager.embeddings[name]["embedding"] for name in self.speaker_manager.embeddings]
-            d_vector = (random.sample(sorted(d_vector), 1),)
-
-        aux_inputs = {
-            "speaker_id": (
-                None
-                if not self.config.use_speaker_embedding
-                else random.sample(sorted(self.speaker_manager.name_to_id.values()), 1)
-            ),
-            "d_vector": d_vector,
-            "style_wav": None,  # TODO: handle GST style input
-        }
-        return aux_inputs
-
     def test_run(self, assets: dict) -> tuple[dict, dict]:
         """Generic test run for ``vc`` models used by ``Trainer``.
 
@@ -366,12 +220,4 @@ class BaseVC(BaseTrainerModel):
         raise NotImplementedError
 
     def on_init_start(self, trainer: Trainer) -> None:
-        """Save the speaker.pth and language_ids.json at the beginning of the training. Also update both paths."""
-        if self.speaker_manager is not None:
-            output_path = os.path.join(trainer.output_path, "speakers.pth")
-            self.speaker_manager.save_ids_to_file(output_path)
-            trainer.config.speakers_file = output_path
-            trainer.config.model_args.speakers_file = output_path
-            trainer.config.save_json(os.path.join(trainer.output_path, "config.json"))
-            logger.info("`speakers.pth` is saved to %s", output_path)
-            logger.info("`speakers_file` is updated in the config.json.")
+        """Run before training starts."""

--- a/TTS/vc/models/base_vc.py
+++ b/TTS/vc/models/base_vc.py
@@ -276,77 +276,73 @@ class BaseVC(BaseTrainerModel):
         num_gpus: int,
         rank: int | None = None,
     ) -> "DataLoader":
-        if is_eval and not config.run_eval:
-            loader = None
+        # setup multi-speaker attributes
+        if self.speaker_manager is not None:
+            if hasattr(config, "model_args"):
+                speaker_id_mapping = (
+                    self.speaker_manager.name_to_id if config.model_args.use_speaker_embedding else None
+                )
+                d_vector_mapping = self.speaker_manager.embeddings if config.model_args.use_d_vector_file else None
+                config.use_d_vector_file = config.model_args.use_d_vector_file
+            else:
+                speaker_id_mapping = self.speaker_manager.name_to_id if config.use_speaker_embedding else None
+                d_vector_mapping = self.speaker_manager.embeddings if config.use_d_vector_file else None
         else:
-            # setup multi-speaker attributes
-            if self.speaker_manager is not None:
-                if hasattr(config, "model_args"):
-                    speaker_id_mapping = (
-                        self.speaker_manager.name_to_id if config.model_args.use_speaker_embedding else None
-                    )
-                    d_vector_mapping = self.speaker_manager.embeddings if config.model_args.use_d_vector_file else None
-                    config.use_d_vector_file = config.model_args.use_d_vector_file
-                else:
-                    speaker_id_mapping = self.speaker_manager.name_to_id if config.use_speaker_embedding else None
-                    d_vector_mapping = self.speaker_manager.embeddings if config.use_d_vector_file else None
-            else:
-                speaker_id_mapping = None
-                d_vector_mapping = None
+            speaker_id_mapping = None
+            d_vector_mapping = None
 
-            # setup multi-lingual attributes
-            if self.language_manager is not None:
-                language_id_mapping = self.language_manager.name_to_id if self.args.use_language_embedding else None
-            else:
-                language_id_mapping = None
+        # setup multi-lingual attributes
+        if self.language_manager is not None:
+            language_id_mapping = self.language_manager.name_to_id if self.args.use_language_embedding else None
+        else:
+            language_id_mapping = None
 
-            # init dataloader
-            dataset = TTSDataset(
-                outputs_per_step=config.r if "r" in config else 1,
-                compute_linear_spec=config.model.lower() == "tacotron" or config.compute_linear_spec,
-                compute_f0=config.get("compute_f0", False),
-                f0_cache_path=config.get("f0_cache_path", None),
-                compute_energy=config.get("compute_energy", False),
-                energy_cache_path=config.get("energy_cache_path", None),
-                samples=samples,
-                ap=self.ap,
-                return_wav=config.return_wav if "return_wav" in config else False,
-                batch_group_size=0 if is_eval else config.batch_group_size * config.batch_size,
-                min_text_len=config.min_text_len,
-                max_text_len=config.max_text_len,
-                min_audio_len=config.min_audio_len,
-                max_audio_len=config.max_audio_len,
-                phoneme_cache_path=config.phoneme_cache_path,
-                precompute_num_workers=config.precompute_num_workers,
-                use_noise_augment=False if is_eval else config.use_noise_augment,
-                speaker_id_mapping=speaker_id_mapping,
-                d_vector_mapping=d_vector_mapping if config.use_d_vector_file else None,
-                tokenizer=None,
-                start_by_longest=config.start_by_longest,
-                language_id_mapping=language_id_mapping,
-            )
+        # init dataloader
+        dataset = TTSDataset(
+            outputs_per_step=config.r if "r" in config else 1,
+            compute_linear_spec=config.model.lower() == "tacotron" or config.compute_linear_spec,
+            compute_f0=config.get("compute_f0", False),
+            f0_cache_path=config.get("f0_cache_path", None),
+            compute_energy=config.get("compute_energy", False),
+            energy_cache_path=config.get("energy_cache_path", None),
+            samples=samples,
+            ap=self.ap,
+            return_wav=config.return_wav if "return_wav" in config else False,
+            batch_group_size=0 if is_eval else config.batch_group_size * config.batch_size,
+            min_text_len=config.min_text_len,
+            max_text_len=config.max_text_len,
+            min_audio_len=config.min_audio_len,
+            max_audio_len=config.max_audio_len,
+            phoneme_cache_path=config.phoneme_cache_path,
+            precompute_num_workers=config.precompute_num_workers,
+            use_noise_augment=False if is_eval else config.use_noise_augment,
+            speaker_id_mapping=speaker_id_mapping,
+            d_vector_mapping=d_vector_mapping if config.use_d_vector_file else None,
+            tokenizer=None,
+            start_by_longest=config.start_by_longest,
+            language_id_mapping=language_id_mapping,
+        )
 
-            # wait all the DDP process to be ready
-            if num_gpus > 1:
-                dist.barrier()
+        # wait all the DDP process to be ready
+        if num_gpus > 1:
+            dist.barrier()
 
-            # sort input sequences from short to long
-            dataset.preprocess_samples()
+        # sort input sequences from short to long
+        dataset.preprocess_samples()
 
-            # get samplers
-            sampler = self.get_sampler(config, dataset, num_gpus)
+        # get samplers
+        sampler = self.get_sampler(config, dataset, num_gpus)
 
-            loader = DataLoader(
-                dataset,
-                batch_size=config.eval_batch_size if is_eval else config.batch_size,
-                shuffle=config.shuffle if sampler is None else False,  # if there is no other sampler
-                collate_fn=dataset.collate_fn,
-                drop_last=config.drop_last,  # setting this False might cause issues in AMP training.
-                sampler=sampler,
-                num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
-                pin_memory=False,
-            )
-        return loader
+        return DataLoader(
+            dataset,
+            batch_size=config.eval_batch_size if is_eval else config.batch_size,
+            shuffle=config.shuffle if sampler is None else False,  # if there is no other sampler
+            collate_fn=dataset.collate_fn,
+            drop_last=config.drop_last,  # setting this False might cause issues in AMP training.
+            sampler=sampler,
+            num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
+            pin_memory=False,
+        )
 
     def _get_test_aux_input(
         self,

--- a/TTS/vc/models/base_vc.py
+++ b/TTS/vc/models/base_vc.py
@@ -68,7 +68,7 @@ class BaseVC(BaseTrainerModel):
         else:
             raise ValueError("config must be either a *Config or *Args")
 
-    def init_multispeaker(self, config: Coqpit, data: list[Any] | None = None) -> None:
+    def init_multispeaker(self, config: Coqpit) -> None:
         """Set up for multi-speaker use.
 
         Initialize a speaker embedding layer if needed and define the expected

--- a/TTS/vc/models/base_vc.py
+++ b/TTS/vc/models/base_vc.py
@@ -12,12 +12,15 @@ from torch.utils.data.sampler import WeightedRandomSampler
 from trainer.torch import DistributedSampler, DistributedSamplerWrapper
 from trainer.trainer import Trainer
 
+from TTS.config import get_from_config_or_model_args
+from TTS.config.shared_configs import ModelArgs
 from TTS.model import BaseTrainerModel
 from TTS.tts.datasets.dataset import TTSDataset
 from TTS.tts.utils.data import get_length_balancer_weights
 from TTS.tts.utils.languages import LanguageManager, get_language_balancer_weights
 from TTS.tts.utils.speakers import SpeakerManager, get_speaker_balancer_weights
 from TTS.utils.audio.processor import AudioProcessor
+from TTS.vc.configs.shared_configs import BaseVCConfig
 
 # pylint: skip-file
 
@@ -44,9 +47,9 @@ class BaseVC(BaseTrainerModel):
         self.ap = ap
         self.speaker_manager = speaker_manager
         self.language_manager = language_manager
-        self._set_model_args(config)
+        self._set_model_args()
 
-    def _set_model_args(self, config: Coqpit) -> None:
+    def _set_model_args(self) -> None:
         """Set up model args based on the config type (``ModelConfig`` or ``ModelArgs``).
 
         ``ModelArgs`` has all the fields required to initialize the model architecture.
@@ -58,12 +61,10 @@ class BaseVC(BaseTrainerModel):
 
         If the config is for the model with a name like ``*Args``, then we assign them directly.
         """
-        # don't use isinstance not to import recursively
-        if "Config" in config.__class__.__name__:
-            self.config = config
-            self.args = config.model_args
-        elif "Args" in config.__class__.__name__:
-            self.args = config
+        if isinstance(self.config, BaseVCConfig):
+            self.args = self.config.model_args
+        elif isinstance(self.config, ModelArgs):
+            self.args = self.config
         else:
             raise ValueError("config must be either a *Config or *Args")
 
@@ -278,15 +279,15 @@ class BaseVC(BaseTrainerModel):
     ) -> "DataLoader":
         # setup multi-speaker attributes
         if self.speaker_manager is not None:
-            if hasattr(config, "model_args"):
-                speaker_id_mapping = (
-                    self.speaker_manager.name_to_id if config.model_args.use_speaker_embedding else None
-                )
-                d_vector_mapping = self.speaker_manager.embeddings if config.model_args.use_d_vector_file else None
-                config.use_d_vector_file = config.model_args.use_d_vector_file
-            else:
-                speaker_id_mapping = self.speaker_manager.name_to_id if config.use_speaker_embedding else None
-                d_vector_mapping = self.speaker_manager.embeddings if config.use_d_vector_file else None
+            speaker_id_mapping = (
+                self.speaker_manager.name_to_id
+                if get_from_config_or_model_args(config, "use_speaker_embedding")
+                else None
+            )
+            d_vector_mapping = (
+                self.speaker_manager.embeddings if get_from_config_or_model_args(config, "use_d_vector_file") else None
+            )
+            config.use_d_vector_file = get_from_config_or_model_args(config, "use_d_vector_file", False)
         else:
             speaker_id_mapping = None
             d_vector_mapping = None
@@ -382,9 +383,7 @@ class BaseVC(BaseTrainerModel):
             output_path = os.path.join(trainer.output_path, "speakers.pth")
             self.speaker_manager.save_ids_to_file(output_path)
             trainer.config.speakers_file = output_path
-            # some models don't have ``model_args`` set
-            if hasattr(trainer.config, "model_args"):
-                trainer.config.model_args.speakers_file = output_path
+            trainer.config.model_args.speakers_file = output_path
             trainer.config.save_json(os.path.join(trainer.output_path, "config.json"))
             logger.info("`speakers.pth` is saved to %s", output_path)
             logger.info("`speakers_file` is updated in the config.json.")
@@ -393,8 +392,7 @@ class BaseVC(BaseTrainerModel):
             output_path = os.path.join(trainer.output_path, "language_ids.json")
             self.language_manager.save_ids_to_file(output_path)
             trainer.config.language_ids_file = output_path
-            if hasattr(trainer.config, "model_args"):
-                trainer.config.model_args.language_ids_file = output_path
+            trainer.config.model_args.language_ids_file = output_path
             trainer.config.save_json(os.path.join(trainer.output_path, "config.json"))
             logger.info("`language_ids.json` is saved to %s", output_path)
             logger.info("`language_ids_file` is updated in the config.json.")

--- a/TTS/vc/models/base_vc.py
+++ b/TTS/vc/models/base_vc.py
@@ -17,7 +17,7 @@ from TTS.config.shared_configs import ModelArgs
 from TTS.model import BaseTrainerModel
 from TTS.tts.datasets.dataset import TTSDataset
 from TTS.tts.utils.data import get_length_balancer_weights
-from TTS.tts.utils.languages import LanguageManager, get_language_balancer_weights
+from TTS.tts.utils.languages import get_language_balancer_weights
 from TTS.tts.utils.speakers import SpeakerManager, get_speaker_balancer_weights
 from TTS.utils.audio.processor import AudioProcessor
 from TTS.vc.configs.shared_configs import BaseVCConfig
@@ -40,13 +40,11 @@ class BaseVC(BaseTrainerModel):
         config: Coqpit,
         ap: AudioProcessor | None = None,
         speaker_manager: SpeakerManager | None = None,
-        language_manager: LanguageManager | None = None,
     ) -> None:
         super().__init__()
         self.config = config
         self.ap = ap
         self.speaker_manager = speaker_manager
-        self.language_manager = language_manager
         self._set_model_args()
 
     def _set_model_args(self) -> None:
@@ -138,10 +136,6 @@ class BaseVC(BaseTrainerModel):
                 else:
                     speaker_id = self.speaker_manager.name_to_id[speaker_name]
 
-        # get language id
-        if self.language_manager is not None and config.use_language_embedding and language_name is not None:
-            language_id = self.language_manager.name_to_id[language_name]
-
         return {
             "text": text,
             "speaker_id": speaker_id,
@@ -176,7 +170,6 @@ class BaseVC(BaseTrainerModel):
         waveform = batch["waveform"]
         pitch = batch["pitch"]
         energy = batch["energy"]
-        language_ids = batch["language_ids"]
         max_text_length = torch.max(text_lengths.float())
         max_spec_length = torch.max(mel_lengths.float())
 
@@ -225,7 +218,6 @@ class BaseVC(BaseTrainerModel):
             "waveform": waveform,
             "pitch": pitch,
             "energy": energy,
-            "language_ids": language_ids,
             "audio_unique_names": batch["audio_unique_names"],
         }
 
@@ -292,11 +284,7 @@ class BaseVC(BaseTrainerModel):
             speaker_id_mapping = None
             d_vector_mapping = None
 
-        # setup multi-lingual attributes
-        if self.language_manager is not None:
-            language_id_mapping = self.language_manager.name_to_id if self.args.use_language_embedding else None
-        else:
-            language_id_mapping = None
+        language_id_mapping = None
 
         # init dataloader
         dataset = TTSDataset(
@@ -387,12 +375,3 @@ class BaseVC(BaseTrainerModel):
             trainer.config.save_json(os.path.join(trainer.output_path, "config.json"))
             logger.info("`speakers.pth` is saved to %s", output_path)
             logger.info("`speakers_file` is updated in the config.json.")
-
-        if self.language_manager is not None:
-            output_path = os.path.join(trainer.output_path, "language_ids.json")
-            self.language_manager.save_ids_to_file(output_path)
-            trainer.config.language_ids_file = output_path
-            trainer.config.model_args.language_ids_file = output_path
-            trainer.config.save_json(os.path.join(trainer.output_path, "config.json"))
-            logger.info("`language_ids.json` is saved to %s", output_path)
-            logger.info("`language_ids_file` is updated in the config.json.")

--- a/TTS/vc/models/freevc.py
+++ b/TTS/vc/models/freevc.py
@@ -261,7 +261,7 @@ class FreeVC(CloningMixin, BaseVC):
     """
 
     def __init__(self, config: Coqpit, speaker_manager: SpeakerManager = None):
-        super().__init__(config, None, speaker_manager, None)
+        super().__init__(config, None, speaker_manager)
 
         self.init_multispeaker(config)
 

--- a/TTS/vc/models/freevc.py
+++ b/TTS/vc/models/freevc.py
@@ -16,7 +16,6 @@ from torch.nn.utils.parametrize import remove_parametrizations
 import TTS.vc.layers.freevc.modules as modules
 from TTS.tts.layers.vits.discriminator import DiscriminatorS
 from TTS.tts.utils.helpers import sequence_mask
-from TTS.tts.utils.speakers import SpeakerManager
 from TTS.utils.voices import CloningMixin
 from TTS.vc.configs.freevc_config import FreeVCConfig
 from TTS.vc.layers.freevc.commons import init_weights, rand_slice_segments
@@ -260,10 +259,8 @@ class FreeVC(CloningMixin, BaseVC):
         >>> model = FreeVC(config)
     """
 
-    def __init__(self, config: Coqpit, speaker_manager: SpeakerManager = None):
-        super().__init__(config, None, speaker_manager)
-
-        self.init_multispeaker(config)
+    def __init__(self, config: Coqpit):
+        super().__init__(config)
 
         self.spec_channels = self.args.spec_channels
         self.inter_channels = self.args.inter_channels
@@ -314,20 +311,6 @@ class FreeVC(CloningMixin, BaseVC):
         self.enc_spk_ex = SpeakerEncoderEx(
             "https://github.com/coqui-ai/TTS/releases/download/v0.13.0_models/speaker_encoder.pt"
         )
-
-    def init_multispeaker(self, config: Coqpit):
-        """Initialize multi-speaker modules of a model. A model can be trained either with a speaker embedding layer
-        or with external `d_vectors` computed from a speaker encoder model.
-
-        You must provide a `speaker_manager` at initialization to set up the multi-speaker modules.
-
-        Args:
-            config (Coqpit): Model configuration.
-            data (List, optional): Dataset items to infer number of speakers. Defaults to None.
-        """
-        self.num_spks = self.args.num_spks
-        if self.speaker_manager:
-            self.num_spks = self.speaker_manager.num_spks
 
     def forward(
         self,

--- a/TTS/vc/models/openvoice.py
+++ b/TTS/vc/models/openvoice.py
@@ -119,7 +119,7 @@ class OpenVoice(CloningMixin, BaseVC):
     """
 
     def __init__(self, config: Coqpit, speaker_manager: SpeakerManager | None = None) -> None:
-        super().__init__(config, None, speaker_manager, None)
+        super().__init__(config, None, speaker_manager)
 
         self.init_multispeaker(config)
 

--- a/TTS/vc/models/openvoice.py
+++ b/TTS/vc/models/openvoice.py
@@ -179,7 +179,7 @@ class OpenVoice(CloningMixin, BaseVC):
     def init_from_config(config: OpenVoiceConfig) -> "OpenVoice":
         return OpenVoice(config)
 
-    def init_multispeaker(self, config: Coqpit, data: list[Any] | None = None) -> None:
+    def init_multispeaker(self, config: Coqpit) -> None:
         """Initialize multi-speaker modules of a model. A model can be trained either with a speaker embedding layer
         or with external `d_vectors` computed from a speaker encoder model.
 
@@ -187,7 +187,6 @@ class OpenVoice(CloningMixin, BaseVC):
 
         Args:
             config (Coqpit): Model configuration.
-            data (list, optional): Dataset items to infer number of speakers. Defaults to None.
         """
         self.num_spks = config.num_speakers
         if self.speaker_manager:

--- a/TTS/vc/models/openvoice.py
+++ b/TTS/vc/models/openvoice.py
@@ -14,7 +14,6 @@ from torch import nn
 from torch.nn import functional as F
 
 from TTS.tts.layers.vits.networks import PosteriorEncoder
-from TTS.tts.utils.speakers import SpeakerManager
 from TTS.utils.audio.torch_transforms import wav_to_spec
 from TTS.utils.voices import CloningMixin
 from TTS.vc.configs.openvoice_config import OpenVoiceConfig
@@ -118,10 +117,8 @@ class OpenVoice(CloningMixin, BaseVC):
     October 2023, serving as the backend of MyShell.
     """
 
-    def __init__(self, config: Coqpit, speaker_manager: SpeakerManager | None = None) -> None:
-        super().__init__(config, None, speaker_manager)
-
-        self.init_multispeaker(config)
+    def __init__(self, config: Coqpit) -> None:
+        super().__init__(config)
 
         self.zero_g = self.args.zero_g
         self.inter_channels = self.args.inter_channels
@@ -178,19 +175,6 @@ class OpenVoice(CloningMixin, BaseVC):
     @staticmethod
     def init_from_config(config: OpenVoiceConfig) -> "OpenVoice":
         return OpenVoice(config)
-
-    def init_multispeaker(self, config: Coqpit) -> None:
-        """Initialize multi-speaker modules of a model. A model can be trained either with a speaker embedding layer
-        or with external `d_vectors` computed from a speaker encoder model.
-
-        You must provide a `speaker_manager` at initialization to set up the multi-speaker modules.
-
-        Args:
-            config (Coqpit): Model configuration.
-        """
-        self.num_spks = config.num_speakers
-        if self.speaker_manager:
-            self.num_spks = self.speaker_manager.num_speakers
 
     def load_checkpoint(
         self,

--- a/TTS/vocoder/models/base_vocoder.py
+++ b/TTS/vocoder/models/base_vocoder.py
@@ -1,6 +1,5 @@
-from coqpit import Coqpit
-
 from TTS.model import BaseTrainerModel
+from TTS.vocoder.configs.shared_configs import BaseVocoderConfig
 
 # pylint: skip-file
 
@@ -22,34 +21,16 @@ class BaseVocoder(BaseTrainerModel):
 
     def __init__(self, config):
         super().__init__()
-        self._set_model_args(config)
+        self.config = config
+        self._set_model_args()
 
-    def _set_model_args(self, config: Coqpit):
-        """Setup model args based on the config type.
-
-        If the config is for training with a name like "*Config", then the model args are embeded in the
-        config.model_args
-
-        If the config is for the model with a name like "*Args", then we assign the directly.
-        """
-        # don't use isintance not to import recursively
-        if "Config" in config.__class__.__name__:
-            if "characters" in config:
-                _, self.config, num_chars = self.get_characters(config)
-                self.config.num_chars = num_chars
-                if hasattr(self.config, "model_args"):
-                    config.model_args.num_chars = num_chars
-                    if "model_args" in config:
-                        self.args = self.config.model_args
-                    # This is for backward compatibility
-                    if "model_params" in config:
-                        self.args = self.config.model_params
-            else:
-                self.config = config
-                if "model_args" in config:
-                    self.args = self.config.model_args
-                # This is for backward compatibility
-                if "model_params" in config:
-                    self.args = self.config.model_params
+    def _set_model_args(self) -> None:
+        """Setup model args from the config."""
+        if isinstance(self.config, BaseVocoderConfig):
+            if "model_args" in self.config:
+                self.args = self.config.model_args
+            # This is for backward compatibility
+            if "model_params" in self.config:
+                self.args = self.config.model_params
         else:
-            raise ValueError("config must be either a *Config or *Args")
+            raise ValueError("config must be an instance of BaseVocoderConfig")

--- a/TTS/vocoder/models/wavegrad.py
+++ b/TTS/vocoder/models/wavegrad.py
@@ -12,6 +12,7 @@ from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from trainer.trainer_utils import get_optimizer, get_scheduler
 
+from TTS.config.shared_configs import ModelArgs
 from TTS.vocoder.datasets import WaveGradDataset
 from TTS.vocoder.layers.wavegrad import Conv1d, DBlock, FiLM, UBlock
 from TTS.vocoder.models.base_vocoder import BaseVocoder
@@ -19,7 +20,7 @@ from TTS.vocoder.utils.generic_utils import plot_results
 
 
 @dataclass
-class WavegradArgs(Coqpit):
+class WavegradArgs(ModelArgs):
     in_channels: int = 80
     out_channels: int = 1
     use_weight_norm: bool = False

--- a/TTS/vocoder/models/wavernn.py
+++ b/TTS/vocoder/models/wavernn.py
@@ -10,6 +10,7 @@ from torch import nn
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 
+from TTS.config.shared_configs import ModelArgs
 from TTS.tts.utils.visual import plot_spectrogram
 from TTS.utils.audio import AudioProcessor
 from TTS.utils.audio.numpy_transforms import mulaw_decode
@@ -132,7 +133,7 @@ class Upsample(nn.Module):
 
 
 @dataclass
-class WavernnArgs(Coqpit):
+class WavernnArgs(ModelArgs):
     """🐸 WaveRNN model arguments.
 
     rnn_dims (int):

--- a/docs/source/extension/implementing_a_new_model.md
+++ b/docs/source/extension/implementing_a_new_model.md
@@ -88,11 +88,7 @@ class MyModel(BaseTTS):
 
     def __init__(self, config: Coqpit):
         super().__init__()
-        self._set_model_args(config)
-
-    def _set_model_args(self, config: Coqpit):
-        """Set model arguments from the config. Override this."""
-        pass
+        self._set_model_args()
 
     def forward(self, input: torch.Tensor, *args, aux_input={}, **kwargs) -> Dict:
         """Forward pass for the model mainly used in training.

--- a/tests/integration/test_vits_multilingual_speaker_emb_train.py
+++ b/tests/integration/test_vits_multilingual_speaker_emb_train.py
@@ -56,7 +56,6 @@ def test_train(tmp_path):
 
     # active multilingual mode
     config.model_args.use_language_embedding = True
-    config.use_language_embedding = True
     # active multispeaker mode
     config.model_args.use_speaker_embedding = True
     config.use_speaker_embedding = True

--- a/tests/integration/test_vits_multilingual_train-d_vectors.py
+++ b/tests/integration/test_vits_multilingual_train-d_vectors.py
@@ -54,7 +54,6 @@ def test_train(tmp_path):
 
     # active multilingual mode
     config.model_args.use_language_embedding = True
-    config.use_language_embedding = True
 
     # deactivate multispeaker mode
     config.model_args.use_speaker_embedding = False

--- a/tests/tts_tests/test_glow_tts.py
+++ b/tests/tts_tests/test_glow_tts.py
@@ -7,7 +7,7 @@ from torch import optim
 from trainer.generic_utils import count_parameters
 from trainer.logging.tensorboard_logger import TensorboardLogger
 
-from tests import check_parameter_changes, get_tests_data_path, get_tests_input_path, get_tests_output_path
+from tests import assert_parameters_change, get_tests_data_path, get_tests_input_path, get_tests_output_path
 from TTS.tts.configs.glow_tts_config import GlowTTSConfig
 from TTS.tts.layers.losses import GlowTTSLoss
 from TTS.tts.models.glow_tts import GlowTTS
@@ -277,7 +277,7 @@ class TestGlowTTS(unittest.TestCase):
             loss.backward()
             optimizer.step()
         # check parameter changes
-        check_parameter_changes(model, model_ref)
+        assert_parameters_change(model, model_ref)
 
     def test_train_eval_log(self):
         batch_size = BATCH_SIZE

--- a/tests/tts_tests/test_overflow.py
+++ b/tests/tts_tests/test_overflow.py
@@ -1,8 +1,7 @@
-import os
 import random
-import unittest
-from copy import deepcopy
+from pathlib import Path
 
+import pytest
 import torch
 
 from tests import get_tests_output_path
@@ -12,176 +11,189 @@ from TTS.tts.layers.overflow.decoder import Decoder
 from TTS.tts.layers.overflow.neural_hmm import EmissionModel, NeuralHMM, TransitionModel
 from TTS.tts.models.overflow import Overflow
 from TTS.tts.utils.helpers import sequence_mask
-from TTS.utils.audio import AudioProcessor
-
-# pylint: disable=unused-variable
-
-torch.manual_seed(1)
-use_cuda = torch.cuda.is_available()
-device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-
-config_global = OverflowConfig(num_chars=24)
-ap = AudioProcessor.init_from_config(config_global)
-
-config_path = os.path.join(get_tests_output_path(), "test_model_config.json")
-output_path = os.path.join(get_tests_output_path(), "train_outputs")
-parameter_path = os.path.join(get_tests_output_path(), "lj_parameters.pt")
-
-torch.save({"mean": -5.5138, "std": 2.0636, "init_transition_prob": 0.3212}, parameter_path)
 
 
-def _create_inputs(batch_size=8):
-    max_len_t, max_len_m = random.randint(25, 50), random.randint(50, 80)
-    input_dummy = torch.randint(0, 24, (batch_size, max_len_t)).long().to(device)
-    input_lengths = torch.randint(20, max_len_t, (batch_size,)).long().to(device).sort(descending=True)[0]
-    input_lengths[0] = max_len_t
-    input_dummy = input_dummy * sequence_mask(input_lengths)
-    mel_spec = torch.randn(batch_size, max_len_m, config_global.audio["num_mels"]).to(device)
-    mel_lengths = torch.randint(40, max_len_m, (batch_size,)).long().to(device).sort(descending=True)[0]
-    mel_lengths[0] = max_len_m
-    mel_spec = mel_spec * sequence_mask(mel_lengths).unsqueeze(2)
-    return input_dummy, input_lengths, mel_spec, mel_lengths
+@pytest.fixture(scope="session")
+def device():
+    """Get torch device for testing."""
+    return torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
 
-def get_model(config=None):
-    if config is None:
-        config = config_global
+@pytest.fixture(scope="session")
+def parameter_path() -> Path:
+    """Create and return path to test parameters."""
+    path = Path(get_tests_output_path()) / "lj_parameters.pt"
+    torch.save({"mean": -5.5138, "std": 2.0636, "init_transition_prob": 0.3212}, path)
+    return path
+
+
+@pytest.fixture
+def config():
+    """Create a fresh config for each test."""
+    return OverflowConfig(num_chars=24)
+
+
+@pytest.fixture
+def create_inputs(device, config):
+    """Factory fixture to create test inputs."""
+
+    def _create_inputs(batch_size=8):
+        max_len_t, max_len_m = random.randint(25, 50), random.randint(50, 80)
+        input_dummy = torch.randint(0, 24, (batch_size, max_len_t)).long().to(device)
+        input_lengths = torch.randint(20, max_len_t, (batch_size,)).long().to(device).sort(descending=True)[0]
+        input_lengths[0] = max_len_t
+        input_dummy = input_dummy * sequence_mask(input_lengths)
+        mel_spec = torch.randn(batch_size, max_len_m, config.audio["num_mels"]).to(device)
+        mel_lengths = torch.randint(40, max_len_m, (batch_size,)).long().to(device).sort(descending=True)[0]
+        mel_lengths[0] = max_len_m
+        mel_spec = mel_spec * sequence_mask(mel_lengths).unsqueeze(2)
+        return input_dummy, input_lengths, mel_spec, mel_lengths
+
+    return _create_inputs
+
+
+@pytest.fixture
+def get_overflow_model(config, parameter_path, device):
+    """Factory fixture to create Overflow model."""
+
+    def _get_model(custom_config=None):
+        cfg = custom_config if custom_config is not None else config
+        cfg.mel_statistics_parameter_path = parameter_path
+        model = Overflow(cfg)
+        return model.to(device)
+
+    return _get_model
+
+
+@pytest.fixture(autouse=True)
+def set_random_seed():
+    """Set random seed for reproducibility."""
+    torch.manual_seed(1)
+
+
+# Tests for Overflow model
+
+
+def test_overflow_forward(get_overflow_model, create_inputs):
+    model = get_overflow_model()
+    input_dummy, input_lengths, mel_spec, mel_lengths = create_inputs()
+    outputs = model(input_dummy, input_lengths, mel_spec, mel_lengths)
+    assert outputs["log_probs"].shape == (input_dummy.shape[0],)
+    assert outputs["alignments"].shape[2] == model.state_per_phone * max(input_lengths)
+
+
+def test_overflow_inference(get_overflow_model, create_inputs, config):
+    model = get_overflow_model()
+    input_dummy, input_lengths, mel_spec, mel_lengths = create_inputs()
+    output_dict = model.inference(input_dummy)
+    assert output_dict["model_outputs"].shape[2] == config.out_channels
+
+
+def test_overflow_init_from_config(config, parameter_path):
     config.mel_statistics_parameter_path = parameter_path
-    model = Overflow(config)
-    model = model.to(device)
-    return model
+    config.prenet_dim = 256
+    model = Overflow.init_from_config(config)
+    assert model.prenet_dim == config.prenet_dim
 
 
-def reset_all_weights(model):
-    """
-    refs:
-        - https://discuss.pytorch.org/t/how-to-re-set-alll-parameters-in-a-network/20819/6
-        - https://stackoverflow.com/questions/63627997/reset-parameters-of-a-neural-network-in-pytorch
-        - https://pytorch.org/docs/stable/generated/torch.nn.Module.html
-    """
-
-    @torch.no_grad()
-    def weight_reset(m):
-        # - check if the current module has reset_parameters & if it's callabed called it on m
-        reset_parameters = getattr(m, "reset_parameters", None)
-        if callable(reset_parameters):
-            m.reset_parameters()
-
-    # Applies fn recursively to every submodule see: https://pytorch.org/docs/stable/generated/torch.nn.Module.html
-    model.apply(fn=weight_reset)
+# Tests for Overflow Encoder
 
 
-class TestOverflow(unittest.TestCase):
-    def test_forward(self):
-        model = get_model()
-        input_dummy, input_lengths, mel_spec, mel_lengths = _create_inputs()
-        outputs = model(input_dummy, input_lengths, mel_spec, mel_lengths)
-        self.assertEqual(outputs["log_probs"].shape, (input_dummy.shape[0],))
-        self.assertEqual(model.state_per_phone * max(input_lengths), outputs["alignments"].shape[2])
+@pytest.fixture
+def get_encoder(config, device):
+    """Factory fixture to create Encoder."""
 
-    def test_inference(self):
-        model = get_model()
-        input_dummy, input_lengths, mel_spec, mel_lengths = _create_inputs()
-        output_dict = model.inference(input_dummy)
-        self.assertEqual(output_dict["model_outputs"].shape[2], config_global.out_channels)
+    def _get_encoder(state_per_phone):
+        return Encoder(config.num_chars, state_per_phone, config.prenet_dim, config.encoder_n_convolutions).to(device)
 
-    def test_init_from_config(self):
-        config = deepcopy(config_global)
-        config.mel_statistics_parameter_path = parameter_path
-        config.prenet_dim = 256
-        model = Overflow.init_from_config(config_global)
-        self.assertEqual(model.prenet_dim, config.prenet_dim)
+    return _get_encoder
 
 
-class TestOverflowEncoder(unittest.TestCase):
-    @staticmethod
-    def get_encoder(state_per_phone):
-        config = deepcopy(config_global)
-        config.state_per_phone = state_per_phone
-        config.num_chars = 24
-        return Encoder(config.num_chars, config.state_per_phone, config.prenet_dim, config.encoder_n_convolutions).to(
-            device
-        )
-
-    def test_forward_with_state_per_phone_multiplication(self):
-        for s_p_p in [1, 2, 3]:
-            input_dummy, input_lengths, _, _ = _create_inputs()
-            model = self.get_encoder(s_p_p)
-            x, x_len = model(input_dummy, input_lengths)
-            self.assertEqual(x.shape[1], input_dummy.shape[1] * s_p_p)
-
-    def test_inference_with_state_per_phone_multiplication(self):
-        for s_p_p in [1, 2, 3]:
-            input_dummy, input_lengths, _, _ = _create_inputs()
-            model = self.get_encoder(s_p_p)
-            x, x_len = model.inference(input_dummy, input_lengths)
-            self.assertEqual(x.shape[1], input_dummy.shape[1] * s_p_p)
+@pytest.mark.parametrize("state_per_phone", [1, 2, 3])
+def test_encoder_forward_with_state_per_phone_multiplication(get_encoder, create_inputs, state_per_phone):
+    input_dummy, input_lengths, _, _ = create_inputs()
+    model = get_encoder(state_per_phone)
+    x, x_len = model(input_dummy, input_lengths)
+    assert x.shape[1] == input_dummy.shape[1] * state_per_phone
 
 
-class TestOverflowUtils(unittest.TestCase):
-    def test_logsumexp(self):
-        a = torch.randn(10)  # random numbers
-        self.assertTrue(torch.eq(torch.logsumexp(a, dim=0), OverflowUtils.logsumexp(a, dim=0)).all())
-
-        a = torch.zeros(10)  # all zeros
-        self.assertTrue(torch.eq(torch.logsumexp(a, dim=0), OverflowUtils.logsumexp(a, dim=0)).all())
-
-        a = torch.ones(10)  # all ones
-        self.assertTrue(torch.eq(torch.logsumexp(a, dim=0), OverflowUtils.logsumexp(a, dim=0)).all())
+@pytest.mark.parametrize("state_per_phone", [1, 2, 3])
+def test_encoder_inference_with_state_per_phone_multiplication(get_encoder, create_inputs, state_per_phone):
+    input_dummy, input_lengths, _, _ = create_inputs()
+    model = get_encoder(state_per_phone)
+    x, x_len = model.inference(input_dummy, input_lengths)
+    assert x.shape[1] == input_dummy.shape[1] * state_per_phone
 
 
-class TestOverflowDecoder(unittest.TestCase):
-    @staticmethod
-    def _get_decoder(num_flow_blocks_dec=None, hidden_channels_dec=None, reset_weights=True):
-        config = deepcopy(config_global)
-        config.num_flow_blocks_dec = (
-            num_flow_blocks_dec if num_flow_blocks_dec is not None else config.num_flow_blocks_dec
-        )
-        config.hidden_channels_dec = (
-            hidden_channels_dec if hidden_channels_dec is not None else config.hidden_channels_dec
-        )
-        config.dropout_p_dec = 0.0  # turn off dropout to check invertibility
-        decoder = Decoder(
+# Tests for Overflow Utils
+
+
+@pytest.mark.parametrize(
+    "tensor",
+    [torch.randn(10), torch.zeros(10), torch.ones(10)],
+    ids=["random", "zeros", "ones"],
+)
+def test_overflow_utils_logsumexp(tensor):
+    assert torch.eq(torch.logsumexp(tensor, dim=0), OverflowUtils.logsumexp(tensor, dim=0)).all()
+
+
+# Tests for Overflow Decoder
+
+
+@pytest.fixture
+def get_decoder(config, device):
+    """Factory fixture to create Decoder."""
+
+    def _get_decoder(num_flow_blocks_dec=None, hidden_channels_dec=None):
+        num_blocks = num_flow_blocks_dec if num_flow_blocks_dec is not None else config.num_flow_blocks_dec
+        hidden_channels = hidden_channels_dec if hidden_channels_dec is not None else config.hidden_channels_dec
+        dropout_p_dec = 0.0  # turn off dropout to check invertibility
+
+        return Decoder(
             config.out_channels,
-            config.hidden_channels_dec,
+            hidden_channels,
             config.kernel_size_dec,
             config.dilation_rate,
-            config.num_flow_blocks_dec,
+            num_blocks,
             config.num_block_layers,
-            config.dropout_p_dec,
+            dropout_p_dec,
             config.num_splits,
             config.num_squeeze,
             config.sigmoid_scale,
             config.c_in_channels,
         ).to(device)
-        if reset_weights:
-            reset_all_weights(decoder)
-        return decoder
 
-    def test_decoder_forward_backward(self):
-        for num_flow_blocks_dec in [8, None]:
-            for hidden_channels_dec in [100, None]:
-                decoder = self._get_decoder(num_flow_blocks_dec, hidden_channels_dec)
-                _, _, mel_spec, mel_lengths = _create_inputs()
-                z, z_len, _ = decoder(mel_spec.transpose(1, 2), mel_lengths)
-                mel_spec_, mel_lengths_, _ = decoder(z, z_len, reverse=True)
-                mask = sequence_mask(z_len).unsqueeze(1)
-                mel_spec = mel_spec[:, : z.shape[2], :].transpose(1, 2) * mask
-                z = z * mask
-                self.assertTrue(
-                    torch.isclose(mel_spec, mel_spec_, atol=1e-2).all(),
-                    f"num_flow_blocks_dec={num_flow_blocks_dec}, hidden_channels_dec={hidden_channels_dec}",
-                )
+    return _get_decoder
 
 
-class TestNeuralHMM(unittest.TestCase):
-    @staticmethod
+@pytest.mark.parametrize("num_flow_blocks_dec", [8, None])
+@pytest.mark.parametrize("hidden_channels_dec", [100, None])
+def test_decoder_forward_backward(get_decoder, create_inputs, num_flow_blocks_dec, hidden_channels_dec):
+    decoder = get_decoder(num_flow_blocks_dec, hidden_channels_dec)
+    _, _, mel_spec, mel_lengths = create_inputs()
+    z, z_len, _ = decoder(mel_spec.transpose(1, 2), mel_lengths)
+    mel_spec_, mel_lengths_, _ = decoder(z, z_len, reverse=True)
+    mask = sequence_mask(z_len).unsqueeze(1)
+    mel_spec = mel_spec[:, : z.shape[2], :].transpose(1, 2) * mask
+    z = z * mask
+    assert torch.isclose(mel_spec, mel_spec_, atol=1e-2).all(), (
+        f"num_flow_blocks_dec={num_flow_blocks_dec}, hidden_channels_dec={hidden_channels_dec}"
+    )
+
+
+# Tests for Neural HMM
+
+
+@pytest.fixture
+def get_neural_hmm(config, device):
+    """Factory fixture to create NeuralHMM."""
+
     def _get_neural_hmm(deterministic_transition=None):
-        config = deepcopy(config_global)
-        neural_hmm = NeuralHMM(
+        det_trans = config.deterministic_transition if deterministic_transition is None else deterministic_transition
+        return NeuralHMM(
             config.out_channels,
             config.ar_order,
-            config.deterministic_transition if deterministic_transition is None else deterministic_transition,
+            det_trans,
             config.encoder_in_out_features,
             config.prenet_type,
             config.prenet_dim,
@@ -193,207 +205,195 @@ class TestNeuralHMM(unittest.TestCase):
             config.flat_start_params,
             config.std_floor,
         ).to(device)
-        return neural_hmm
 
-    @staticmethod
-    def _get_emission_model():
-        return EmissionModel().to(device)
+    return _get_neural_hmm
 
-    @staticmethod
-    def _get_transition_model():
-        return TransitionModel().to(device)
 
-    @staticmethod
+@pytest.fixture
+def get_embedded_input(create_inputs, config, device):
+    """Factory fixture to create embedded inputs."""
+
     def _get_embedded_input():
-        input_dummy, input_lengths, mel_spec, mel_lengths = _create_inputs()
-        input_dummy = torch.nn.Embedding(config_global.num_chars, config_global.encoder_in_out_features).to(device)(
-            input_dummy
-        )
+        input_dummy, input_lengths, mel_spec, mel_lengths = create_inputs()
+        input_dummy = torch.nn.Embedding(config.num_chars, config.encoder_in_out_features).to(device)(input_dummy)
         return input_dummy, input_lengths, mel_spec, mel_lengths
 
-    def test_neural_hmm_forward(self):
-        input_dummy, input_lengths, mel_spec, mel_lengths = self._get_embedded_input()
-        neural_hmm = self._get_neural_hmm()
-        log_prob, log_alpha_scaled, transition_matrix, means = neural_hmm(
-            input_dummy, input_lengths, mel_spec.transpose(1, 2), mel_lengths
+    return _get_embedded_input
+
+
+def test_neural_hmm_forward(get_neural_hmm, get_embedded_input):
+    input_dummy, input_lengths, mel_spec, mel_lengths = get_embedded_input()
+    neural_hmm = get_neural_hmm()
+    log_prob, log_alpha_scaled, transition_matrix, means = neural_hmm(
+        input_dummy, input_lengths, mel_spec.transpose(1, 2), mel_lengths
+    )
+    assert log_prob.shape == (input_dummy.shape[0],)
+    assert log_alpha_scaled.shape == transition_matrix.shape
+
+
+def test_neural_hmm_mask_lengths(get_neural_hmm, get_embedded_input, device):
+    input_dummy, input_lengths, mel_spec, mel_lengths = get_embedded_input()
+    neural_hmm = get_neural_hmm()
+    log_prob, log_alpha_scaled, transition_matrix, means = neural_hmm(
+        input_dummy, input_lengths, mel_spec.transpose(1, 2), mel_lengths
+    )
+    log_c = torch.randn(mel_spec.shape[0], mel_spec.shape[1], device=device)
+    log_c, log_alpha_scaled = neural_hmm._mask_lengths(  # pylint: disable=protected-access
+        mel_lengths, log_c, log_alpha_scaled
+    )
+    assertions = []
+    for i in range(mel_spec.shape[0]):
+        assertions.append(log_c[i, mel_lengths[i] :].sum() == 0.0)
+    assert all(assertions), "Incorrect masking"
+    assertions = []
+    for i in range(mel_spec.shape[0]):
+        assertions.append(log_alpha_scaled[i, mel_lengths[i] :, : input_lengths[i]].sum() == 0.0)
+    assert all(assertions), "Incorrect masking"
+
+
+def test_neural_hmm_process_ar_timestep(get_neural_hmm, get_embedded_input, config):
+    model = get_neural_hmm()
+    input_dummy, input_lengths, mel_spec, mel_lengths = get_embedded_input()
+
+    h_post_prenet, c_post_prenet = model._init_lstm_states(  # pylint: disable=protected-access
+        input_dummy.shape[0], config.memory_rnn_dim, mel_spec
+    )
+    h_post_prenet, c_post_prenet = model._process_ar_timestep(  # pylint: disable=protected-access
+        1,
+        mel_spec,
+        h_post_prenet,
+        c_post_prenet,
+    )
+
+    assert h_post_prenet.shape == (input_dummy.shape[0], config.memory_rnn_dim)
+    assert c_post_prenet.shape == (input_dummy.shape[0], config.memory_rnn_dim)
+
+
+def test_neural_hmm_add_go_token(get_neural_hmm, get_embedded_input):
+    model = get_neural_hmm()
+    input_dummy, input_lengths, mel_spec, mel_lengths = get_embedded_input()
+
+    out = model._add_go_token(mel_spec)  # pylint: disable=protected-access
+    assert out.shape == mel_spec.shape
+    assert (out[:, 1:] == mel_spec[:, :-1]).all(), "Go token not appended properly"
+
+
+def test_neural_hmm_forward_algorithm_variables(get_neural_hmm, get_embedded_input, config):
+    model = get_neural_hmm()
+    input_dummy, input_lengths, mel_spec, mel_lengths = get_embedded_input()
+
+    (
+        log_c,
+        log_alpha_scaled,
+        transition_matrix,
+        _,
+    ) = model._initialize_forward_algorithm_variables(  # pylint: disable=protected-access
+        mel_spec, input_dummy.shape[1] * config.state_per_phone
+    )
+
+    assert log_c.shape == (mel_spec.shape[0], mel_spec.shape[1])
+    assert log_alpha_scaled.shape == (
+        mel_spec.shape[0],
+        mel_spec.shape[1],
+        input_dummy.shape[1] * config.state_per_phone,
+    )
+    assert transition_matrix.shape == (
+        mel_spec.shape[0],
+        mel_spec.shape[1],
+        input_dummy.shape[1] * config.state_per_phone,
+    )
+
+
+def test_neural_hmm_get_absorption_state_scaling_factor(get_neural_hmm, get_embedded_input, config):
+    model = get_neural_hmm()
+    input_dummy, input_lengths, mel_spec, mel_lengths = get_embedded_input()
+    input_lengths = input_lengths * config.state_per_phone
+    (
+        log_c,
+        log_alpha_scaled,
+        transition_matrix,
+        _,
+    ) = model._initialize_forward_algorithm_variables(  # pylint: disable=protected-access
+        mel_spec, input_dummy.shape[1] * config.state_per_phone
+    )
+    log_alpha_scaled = torch.rand_like(log_alpha_scaled).clamp(1e-3)
+    transition_matrix = torch.randn_like(transition_matrix).sigmoid().log()
+    sum_final_log_c = model.get_absorption_state_scaling_factor(
+        mel_lengths, log_alpha_scaled, input_lengths, transition_matrix
+    )
+
+    text_mask = ~sequence_mask(input_lengths)
+    transition_prob_mask = ~model.get_mask_for_last_item(input_lengths, device=input_lengths.device)
+
+    outputs = []
+
+    for i in range(input_dummy.shape[0]):
+        last_log_alpha_scaled = log_alpha_scaled[i, mel_lengths[i] - 1].masked_fill(text_mask[i], -float("inf"))
+        log_last_transition_probability = OverflowUtils.log_clamped(
+            torch.sigmoid(transition_matrix[i, mel_lengths[i] - 1])
+        ).masked_fill(transition_prob_mask[i], -float("inf"))
+        outputs.append(last_log_alpha_scaled + log_last_transition_probability)
+
+    sum_final_log_c_computed = torch.logsumexp(torch.stack(outputs), dim=1)
+
+    assert torch.isclose(sum_final_log_c_computed, sum_final_log_c).all()
+
+
+def test_neural_hmm_inference(get_neural_hmm, get_embedded_input, config):
+    model = get_neural_hmm()
+    input_dummy, input_lengths, mel_spec, mel_lengths = get_embedded_input()
+    for temperature in [0.334, 0.667, 1.0]:
+        outputs = model.inference(
+            input_dummy, input_lengths, temperature, config.max_sampling_time, config.duration_threshold
         )
-        self.assertEqual(log_prob.shape, (input_dummy.shape[0],))
-        self.assertEqual(log_alpha_scaled.shape, transition_matrix.shape)
-
-    def test_mask_lengths(self):
-        input_dummy, input_lengths, mel_spec, mel_lengths = self._get_embedded_input()
-        neural_hmm = self._get_neural_hmm()
-        log_prob, log_alpha_scaled, transition_matrix, means = neural_hmm(
-            input_dummy, input_lengths, mel_spec.transpose(1, 2), mel_lengths
-        )
-        log_c = torch.randn(mel_spec.shape[0], mel_spec.shape[1], device=device)
-        log_c, log_alpha_scaled = neural_hmm._mask_lengths(  # pylint: disable=protected-access
-            mel_lengths, log_c, log_alpha_scaled
-        )
-        assertions = []
-        for i in range(mel_spec.shape[0]):
-            assertions.append(log_c[i, mel_lengths[i] :].sum() == 0.0)
-        self.assertTrue(all(assertions), "Incorrect masking")
-        assertions = []
-        for i in range(mel_spec.shape[0]):
-            assertions.append(log_alpha_scaled[i, mel_lengths[i] :, : input_lengths[i]].sum() == 0.0)
-        self.assertTrue(all(assertions), "Incorrect masking")
-
-    def test_process_ar_timestep(self):
-        model = self._get_neural_hmm()
-        input_dummy, input_lengths, mel_spec, mel_lengths = self._get_embedded_input()
-
-        h_post_prenet, c_post_prenet = model._init_lstm_states(  # pylint: disable=protected-access
-            input_dummy.shape[0], config_global.memory_rnn_dim, mel_spec
-        )
-        h_post_prenet, c_post_prenet = model._process_ar_timestep(  # pylint: disable=protected-access
-            1,
-            mel_spec,
-            h_post_prenet,
-            c_post_prenet,
-        )
-
-        self.assertEqual(h_post_prenet.shape, (input_dummy.shape[0], config_global.memory_rnn_dim))
-        self.assertEqual(c_post_prenet.shape, (input_dummy.shape[0], config_global.memory_rnn_dim))
-
-    def test_add_go_token(self):
-        model = self._get_neural_hmm()
-        input_dummy, input_lengths, mel_spec, mel_lengths = self._get_embedded_input()
-
-        out = model._add_go_token(mel_spec)  # pylint: disable=protected-access
-        self.assertEqual(out.shape, mel_spec.shape)
-        self.assertTrue((out[:, 1:] == mel_spec[:, :-1]).all(), "Go token not appended properly")
-
-    def test_forward_algorithm_variables(self):
-        model = self._get_neural_hmm()
-        input_dummy, input_lengths, mel_spec, mel_lengths = self._get_embedded_input()
-
-        (
-            log_c,
-            log_alpha_scaled,
-            transition_matrix,
-            _,
-        ) = model._initialize_forward_algorithm_variables(  # pylint: disable=protected-access
-            mel_spec, input_dummy.shape[1] * config_global.state_per_phone
-        )
-
-        self.assertEqual(log_c.shape, (mel_spec.shape[0], mel_spec.shape[1]))
-        self.assertEqual(
-            log_alpha_scaled.shape,
-            (
-                mel_spec.shape[0],
-                mel_spec.shape[1],
-                input_dummy.shape[1] * config_global.state_per_phone,
-            ),
-        )
-        self.assertEqual(
-            transition_matrix.shape,
-            (mel_spec.shape[0], mel_spec.shape[1], input_dummy.shape[1] * config_global.state_per_phone),
-        )
-
-    def test_get_absorption_state_scaling_factor(self):
-        model = self._get_neural_hmm()
-        input_dummy, input_lengths, mel_spec, mel_lengths = self._get_embedded_input()
-        input_lengths = input_lengths * config_global.state_per_phone
-        (
-            log_c,
-            log_alpha_scaled,
-            transition_matrix,
-            _,
-        ) = model._initialize_forward_algorithm_variables(  # pylint: disable=protected-access
-            mel_spec, input_dummy.shape[1] * config_global.state_per_phone
-        )
-        log_alpha_scaled = torch.rand_like(log_alpha_scaled).clamp(1e-3)
-        transition_matrix = torch.randn_like(transition_matrix).sigmoid().log()
-        sum_final_log_c = model.get_absorption_state_scaling_factor(
-            mel_lengths, log_alpha_scaled, input_lengths, transition_matrix
-        )
-
-        text_mask = ~sequence_mask(input_lengths)
-        transition_prob_mask = ~model.get_mask_for_last_item(input_lengths, device=input_lengths.device)
-
-        outputs = []
-
-        for i in range(input_dummy.shape[0]):
-            last_log_alpha_scaled = log_alpha_scaled[i, mel_lengths[i] - 1].masked_fill(text_mask[i], -float("inf"))
-            log_last_transition_probability = OverflowUtils.log_clamped(
-                torch.sigmoid(transition_matrix[i, mel_lengths[i] - 1])
-            ).masked_fill(transition_prob_mask[i], -float("inf"))
-            outputs.append(last_log_alpha_scaled + log_last_transition_probability)
-
-        sum_final_log_c_computed = torch.logsumexp(torch.stack(outputs), dim=1)
-
-        self.assertTrue(torch.isclose(sum_final_log_c_computed, sum_final_log_c).all())
-
-    def test_inference(self):
-        model = self._get_neural_hmm()
-        input_dummy, input_lengths, mel_spec, mel_lengths = self._get_embedded_input()
-        for temp in [0.334, 0.667, 1.0]:
-            outputs = model.inference(
-                input_dummy, input_lengths, temp, config_global.max_sampling_time, config_global.duration_threshold
-            )
-            self.assertEqual(outputs["hmm_outputs"].shape[-1], outputs["input_parameters"][0][0][0].shape[-1])
-            self.assertEqual(
-                outputs["output_parameters"][0][0][0].shape[-1], outputs["input_parameters"][0][0][0].shape[-1]
-            )
-            self.assertEqual(len(outputs["alignments"]), input_dummy.shape[0])
-
-    def test_emission_model(self):
-        model = self._get_emission_model()
-        input_dummy, input_lengths, mel_spec, mel_lengths = self._get_embedded_input()
-        x_t = torch.randn(input_dummy.shape[0], config_global.out_channels).to(device)
-        means = torch.randn(input_dummy.shape[0], input_dummy.shape[1], config_global.out_channels).to(device)
-        std = torch.rand_like(means).to(device).clamp_(1e-3)  # std should be positive
-        out = model(x_t, means, std, input_lengths)
-        self.assertEqual(out.shape, (input_dummy.shape[0], input_dummy.shape[1]))
-
-        # testing sampling
-        for temp in [0, 0.334, 0.667]:
-            out = model.sample(means, std, 0)
-            self.assertEqual(out.shape, means.shape)
-            if temp == 0:
-                self.assertTrue(torch.isclose(out, means).all())
-
-    def test_transition_model(self):
-        model = self._get_transition_model()
-        input_dummy, input_lengths, mel_spec, mel_lengths = self._get_embedded_input()
-        prev_t_log_scaled_alph = torch.randn(input_dummy.shape[0], input_lengths.max()).to(device)
-        transition_vector = torch.randn(input_lengths.max()).to(device)
-        out = model(prev_t_log_scaled_alph, transition_vector, input_lengths)
-        self.assertEqual(out.shape, (input_dummy.shape[0], input_lengths.max()))
+        assert outputs["hmm_outputs"].shape[-1] == outputs["input_parameters"][0][0][0].shape[-1]
+        assert outputs["output_parameters"][0][0][0].shape[-1] == outputs["input_parameters"][0][0][0].shape[-1]
+        assert len(outputs["alignments"]) == input_dummy.shape[0]
 
 
-class TestOverflowOutputNet(unittest.TestCase):
-    @staticmethod
-    def _get_outputnet():
-        config = deepcopy(config_global)
-        outputnet = Outputnet(
-            config.encoder_in_out_features,
-            config.memory_rnn_dim,
-            config.out_channels,
-            config.outputnet_size,
-            config.flat_start_params,
-            config.std_floor,
-        ).to(device)
-        return outputnet
+def test_emission_model(get_embedded_input, config, device):
+    model = EmissionModel().to(device)
+    input_dummy, input_lengths, mel_spec, mel_lengths = get_embedded_input()
+    x_t = torch.randn(input_dummy.shape[0], config.out_channels).to(device)
+    means = torch.randn(input_dummy.shape[0], input_dummy.shape[1], config.out_channels).to(device)
+    std = torch.rand_like(means).to(device).clamp_(1e-3)  # std should be positive
+    out = model(x_t, means, std, input_lengths)
+    assert out.shape == (input_dummy.shape[0], input_dummy.shape[1])
 
-    @staticmethod
-    def _get_embedded_input():
-        input_dummy, input_lengths, mel_spec, mel_lengths = _create_inputs()
-        input_dummy = torch.nn.Embedding(config_global.num_chars, config_global.encoder_in_out_features).to(device)(
-            input_dummy
-        )
-        one_timestep_frame = torch.randn(input_dummy.shape[0], config_global.memory_rnn_dim).to(device)
-        return input_dummy, one_timestep_frame
+    # testing sampling
+    for temperature in [0, 0.334, 0.667]:
+        out = model.sample(means, std, temperature)
+        assert out.shape == means.shape
+        if temperature == 0:
+            assert torch.isclose(out, means).all()
 
-    def test_outputnet_forward_with_flat_start(self):
-        model = self._get_outputnet()
-        input_dummy, one_timestep_frame = self._get_embedded_input()
-        mean, std, transition_vector = model(one_timestep_frame, input_dummy)
-        self.assertTrue(torch.isclose(mean, torch.tensor(model.flat_start_params["mean"] * 1.0)).all())
-        self.assertTrue(torch.isclose(std, torch.tensor(model.flat_start_params["std"] * 1.0)).all())
-        self.assertTrue(
-            torch.isclose(
-                transition_vector.sigmoid(), torch.tensor(model.flat_start_params["transition_p"] * 1.0)
-            ).all()
-        )
+
+def test_transition_model(get_embedded_input, device):
+    model = TransitionModel().to(device)
+    input_dummy, input_lengths, mel_spec, mel_lengths = get_embedded_input()
+    prev_t_log_scaled_alph = torch.randn(input_dummy.shape[0], input_lengths.max()).to(input_dummy.device)
+    transition_vector = torch.randn(input_lengths.max()).to(input_dummy.device)
+    out = model(prev_t_log_scaled_alph, transition_vector, input_lengths)
+    assert out.shape == (input_dummy.shape[0], input_lengths.max())
+
+
+# Tests for Overflow OutputNet
+
+
+def test_outputnet_forward_with_flat_start(create_inputs, config, device):
+    model = Outputnet(
+        config.encoder_in_out_features,
+        config.memory_rnn_dim,
+        config.out_channels,
+        config.outputnet_size,
+        config.flat_start_params,
+        config.std_floor,
+    ).to(device)
+
+    input_dummy, input_lengths, mel_spec, mel_lengths = create_inputs()
+    input_dummy = torch.nn.Embedding(config.num_chars, config.encoder_in_out_features).to(device)(input_dummy)
+    one_timestep_frame = torch.randn(input_dummy.shape[0], config.memory_rnn_dim).to(device)
+    mean, std, transition_vector = model(one_timestep_frame, input_dummy)
+    assert torch.isclose(mean, torch.tensor(model.flat_start_params["mean"] * 1.0)).all()
+    assert torch.isclose(std, torch.tensor(model.flat_start_params["std"] * 1.0)).all()
+    assert torch.isclose(transition_vector.sigmoid(), torch.tensor(model.flat_start_params["transition_p"] * 1.0)).all()

--- a/tests/vc_tests/test_freevc.py
+++ b/tests/vc_tests/test_freevc.py
@@ -36,7 +36,6 @@ class TestFreeVC(unittest.TestCase):
         config = FreeVCConfig()
         model = FreeVC(config).to(device)
         model.load_pretrained_speaker_encoder()
-        model.init_multispeaker(config)
         wavlm_feats = model.extract_wavlm_features(torch.rand(1, 16000))
         assert wavlm_feats.shape == (1, 1024, 49), wavlm_feats.shape
 


### PR DESCRIPTION
Many models had their own ways to prepare speaker conditioning inputs. This PR replaces those with a shared `_get_speaker_conditioning()` method in BaseTTS and adapts the other models accordingly.