### PR TITLE
Remove `encodec` dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,14 +32,6 @@ on:
         description: "Branch of Coqpit to test"
         required: false
         default: "main"
-    paths-ignore:
-      - '.gitignore'
-      - 'CITATION.cff'
-      - 'CODE_OF_CONDUCT.md'
-      - 'CONTRIBUTING.md'
-      - 'LICENSE.txt'
-      - 'README.md'
-      - 'images/**'
 
 jobs:
   unit:
@@ -49,6 +41,16 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         subset: ["data_tests", "inference_tests", "test_aux", "test_text", "test_tts", "test_vc", "test_vocoder"]
+        uv-resolution: ["highest", "lowest-direct"]
+        exclude:
+          - python-version: "3.10"
+            uv-resolution: "highest"
+          - python-version: "3.11"
+            uv-resolution: "lowest-direct"
+          - python-version: "3.12"
+            uv-resolution: "lowest-direct"
+          - python-version: "3.13"
+            uv-resolution: "lowest-direct"
     steps:
       - uses: actions/checkout@v6
       - name: Setup uv
@@ -71,12 +73,9 @@ jobs:
             uv add git+https://github.com/idiap/coqui-ai-coqpit --branch ${{ github.event.inputs.coqpit_branch }}
           fi
       - name: Unit tests
-        run: |
-          resolution=highest
-          if [ "${{ matrix.python-version }}" == "3.10" ]; then
-            resolution=lowest-direct
-          fi
-          uv run --resolution=$resolution --extra cpu --extra codec --extra server --extra languages make ${{ matrix.subset }}
+        run: >
+          uv run --resolution=${{ matrix.uv-resolution }} --extra cpu
+          --extra codec --extra server --extra languages make ${{ matrix.subset }}
       - name: Upload coverage data
         uses: actions/upload-artifact@v6
         with:
@@ -88,8 +87,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.13"]
         shard: [0, 1, 2, 3, 4, 5]
+        python-version: ["3.10", "3.13"]
+        uv-resolution: ["highest", "lowest-direct"]
+        exclude:
+          - python-version: "3.10"
+            uv-resolution: "highest"
+          - python-version: "3.13"
+            uv-resolution: "lowest-direct"
     steps:
       - uses: actions/checkout@v6
       - name: Setup uv
@@ -115,11 +120,8 @@ jobs:
           uv run --extra cpu pytest tests/integration --collect-only --quiet | grep "::" > integration_tests.txt
           total_shards=6
           shard_tests=$(awk "NR % $total_shards == ${{ matrix.shard }}" integration_tests.txt)
-          resolution=highest
-          if [ "${{ matrix.python-version }}" == "3.10" ]; then
-            resolution=lowest-direct
-          fi
-          uv run --resolution=$resolution --extra cpu --extra codec --extra languages coverage run -m pytest -x -v --durations=0 $shard_tests
+          uv run --resolution=${{ matrix.uv-resolution }} --extra cpu \
+          --extra codec --extra languages coverage run -m pytest -x -v --durations=0 $shard_tests
       - name: Upload coverage data
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
           if [ "${{ matrix.python-version }}" == "3.10" ]; then
             resolution=lowest-direct
           fi
-          uv run --resolution=$resolution --extra codec --extra server --extra languages make ${{ matrix.subset }}
+          uv run --resolution=$resolution --extra cpu --extra codec --extra server --extra languages make ${{ matrix.subset }}
       - name: Upload coverage data
         uses: actions/upload-artifact@v6
         with:
@@ -112,14 +112,14 @@ jobs:
           fi
       - name: Integration tests for shard ${{ matrix.shard }}
         run: |
-          uv run pytest tests/integration --collect-only --quiet | grep "::" > integration_tests.txt
+          uv run --extra cpu pytest tests/integration --collect-only --quiet | grep "::" > integration_tests.txt
           total_shards=6
           shard_tests=$(awk "NR % $total_shards == ${{ matrix.shard }}" integration_tests.txt)
           resolution=highest
           if [ "${{ matrix.python-version }}" == "3.10" ]; then
             resolution=lowest-direct
           fi
-          uv run --resolution=$resolution --extra codec --extra languages coverage run -m pytest -x -v --durations=0 $shard_tests
+          uv run --resolution=$resolution --extra cpu --extra codec --extra languages coverage run -m pytest -x -v --durations=0 $shard_tests
       - name: Upload coverage data
         uses: actions/upload-artifact@v6
         with:
@@ -154,7 +154,7 @@ jobs:
             uv add git+https://github.com/idiap/coqui-ai-coqpit --branch ${{ github.event.inputs.coqpit_branch }}
           fi
       - name: Zoo tests
-        run: uv run --extra codec --extra server --extra languages make test_zoo
+        run: uv run --extra cpu --extra codec --extra server --extra languages make test_zoo
         env:
           NUM_PARTITIONS: 3
           TEST_PARTITION: ${{ matrix.partition }}

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test_text: ## run text tests.
 	coverage run -m pytest -x -v --durations=0 tests/text_tests
 
 test_notebook: ## run Jupyter notebook tests
-	NB_OUTPUT_DIR=/tmp/coqui uv run --with nbval --extra notebooks pytest --nbval-lax notebooks/ \
+	NB_OUTPUT_DIR=/tmp/coqui uv run --with nbval --extra cpu --extra notebooks pytest --nbval-lax notebooks/ \
 		--ignore-glob "notebooks/Tutorial*" \
 		--ignore notebooks/dataset_analysis/CheckDatasetSNR.ipynb
 

--- a/TTS/bin/compute_attention_masks.py
+++ b/TTS/bin/compute_attention_masks.py
@@ -1,8 +1,10 @@
 import argparse
 import logging
+import os
 import sys
 from argparse import RawTextHelpFormatter
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import torch
@@ -14,6 +16,8 @@ from TTS.tts.datasets import load_tts_samples
 from TTS.tts.models import setup_model
 from TTS.tts.utils.text.tokenizer import TTSTokenizer
 from TTS.utils.generic_utils import ConsoleFormatter, setup_logger
+
+logger = logging.getLogger(__name__)
 
 
 def parse_args(arg_list: list[str] | None) -> argparse.Namespace:
@@ -73,24 +77,45 @@ Example run:
 def main(arg_list: list[str] | None = None) -> None:
     setup_logger("TTS", level=logging.INFO, stream=sys.stdout, formatter=ConsoleFormatter())
     args = parse_args(arg_list)
+    compute_attention_masks(
+        args.model_path,
+        args.config_path,
+        args.data_path,
+        output_path=args.output_path,
+        formatter=args.formatter,
+        metafile=args.dataset_metafile,
+        use_cuda=args.use_cuda,
+        batch_size=args.batch_size,
+    )
+    sys.exit(0)
 
-    output_path = Path(args.output_path if args.output_path else args.data_path).resolve()
+
+def compute_attention_masks(
+    model_path: str | os.PathLike[Any],
+    config_path: str | os.PathLike[Any],
+    data_path: str | os.PathLike[Any],
+    *,
+    output_path: str | os.PathLike[Any] | None = None,
+    formatter: str = "ljspeech",
+    metafile: str = "metadata.csv",
+    use_cuda: bool = True,
+    batch_size: int = 16,
+) -> None:
+    output_path = Path(output_path if output_path else data_path).resolve()
     output_path.mkdir(parents=True, exist_ok=True)
 
-    config = load_config(args.config_path)
-    config.eval_batch_size = args.batch_size
+    config = load_config(config_path)
+    config.eval_batch_size = batch_size
     tokenizer, config = TTSTokenizer.init_from_config(config)
 
     # load the model
     model = setup_model(config)
-    model.load_checkpoint(config, args.model_path, eval=True)
-    if args.use_cuda:
+    model.load_checkpoint(config, model_path, eval=True)
+    if use_cuda:
         model.cuda()
 
     # create data loader
-    dataset_config = BaseDatasetConfig(
-        formatter=args.formatter, meta_file_train=args.dataset_metafile, path=args.data_path
-    )
+    dataset_config = BaseDatasetConfig(formatter=formatter, meta_file_train=metafile, path=data_path)
     samples, _ = load_tts_samples(dataset_config, eval_split=False)
     loader = model.get_data_loader(config, assets=None, is_eval=True, samples=samples, verbose=True, num_gpus=0)
 
@@ -106,7 +131,7 @@ def main(arg_list: list[str] | None = None) -> None:
             item_idxs = data["item_idxs"]
 
             # dispatch data to GPU
-            if args.use_cuda:
+            if use_cuda:
                 text_input = text_input.cuda()
                 text_lengths = text_lengths.cuda()
                 mel_input = mel_input.cuda()
@@ -134,20 +159,17 @@ def main(arg_list: list[str] | None = None) -> None:
                 alignment = alignment[: mel_lengths[idx], : text_lengths[idx]].cpu().numpy()
                 # save output
                 wav_file_path = Path(item_idx).resolve()
-                rel_path = wav_file_path.relative_to(Path(args.data_path).resolve())
+                rel_path = wav_file_path.relative_to(Path(data_path).resolve())
                 file_path = (output_path / rel_path).with_name(wav_file_path.stem + "_attn.npy")
                 file_path.parent.mkdir(parents=True, exist_ok=True)
                 file_paths.append([wav_file_path, file_path])
                 np.save(file_path, alignment)
 
-        # output metafile
-        metafile = output_path / "metadata_attn_mask.txt"
-
-        with open(metafile, "w", encoding="utf-8") as f:
+        output_file = output_path / "metadata_attn_mask.txt"
+        with open(output_file, "w", encoding="utf-8") as f:
             for p in file_paths:
                 f.write(f"{p[0]}|{p[1]}\n")
-        print(f" >> Metafile created: {metafile}")
-    sys.exit(0)
+        logger.info("Metafile created: %s", output_file)
 
 
 if __name__ == "__main__":

--- a/TTS/bin/train_encoder.py
+++ b/TTS/bin/train_encoder.py
@@ -18,7 +18,7 @@ from trainer.logging import BaseDashboardLogger, ConsoleLogger, logger_factory
 from trainer.torch import NoamLR
 from trainer.trainer_utils import get_optimizer
 
-from TTS.config import load_config, register_config
+from TTS.config import load_config
 from TTS.encoder.configs.base_encoder_config import BaseEncoderConfig
 from TTS.encoder.dataset import EncoderDataset
 from TTS.encoder.utils.generic_utils import setup_encoder_model
@@ -72,17 +72,12 @@ def process_args(
         if not args.best_path:
             args.best_path = best_model
     # init config if not already defined
-    if config is None:
-        if args.config_path:
-            # init from a file
-            config = load_config(args.config_path)
-        else:
-            # init from console args
-            from TTS.config.shared_configs import BaseTrainingConfig  # pylint: disable=import-outside-toplevel
-
-            config_base = BaseTrainingConfig()
-            config_base.parse_known_args(coqpit_overrides)
-            config = register_config(config_base.model)()
+    if config is None and args.config_path:
+        # init from a file
+        config = load_config(args.config_path)
+    else:
+        msg = "You need to specify either --config_path or --continue_path"
+        raise RuntimeError(msg)
     # override values from command-line args
     config.parse_known_args(coqpit_overrides, relaxed_parser=True)
     experiment_path = args.continue_path

--- a/TTS/bin/train_tts.py
+++ b/TTS/bin/train_tts.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 
 from trainer import Trainer, TrainerArgs
 
-from TTS.config import load_config, register_config
+from TTS.config import load_config
 from TTS.tts.datasets import load_tts_samples
 from TTS.tts.models import setup_model
 from TTS.utils.generic_utils import ConsoleFormatter, setup_logger
@@ -13,7 +13,7 @@ from TTS.utils.generic_utils import ConsoleFormatter, setup_logger
 
 @dataclass
 class TrainTTSArgs(TrainerArgs):
-    config_path: str = field(default=None, metadata={"help": "Path to the config file."})
+    config_path: str | None = field(default=None, metadata={"help": "Path to the config file."})
 
 
 def main(arg_list: list[str] | None = None):
@@ -28,25 +28,20 @@ def main(arg_list: list[str] | None = None):
     args, config_overrides = parser.parse_known_args(arg_list)
     train_args.parse_args(args)
 
-    # load config.json and register
-    if args.config_path or args.continue_path:
-        if args.config_path:
-            # init from a file
-            config = load_config(args.config_path)
-            if len(config_overrides) > 0:
-                config.parse_known_args(config_overrides, relaxed_parser=True)
-        elif args.continue_path:
-            # continue from a prev experiment
-            config = load_config(os.path.join(args.continue_path, "config.json"))
-            if len(config_overrides) > 0:
-                config.parse_known_args(config_overrides, relaxed_parser=True)
-        else:
-            # init from console args
-            from TTS.config.shared_configs import BaseTrainingConfig  # pylint: disable=import-outside-toplevel
-
-            config_base = BaseTrainingConfig()
-            config_base.parse_known_args(config_overrides)
-            config = register_config(config_base.model)()
+    # load config.json
+    if args.config_path:
+        # init from a file
+        config = load_config(args.config_path)
+        if len(config_overrides) > 0:
+            config.parse_known_args(config_overrides, relaxed_parser=True)
+    elif args.continue_path:
+        # continue from a prev experiment
+        config = load_config(os.path.join(args.continue_path, "config.json"))
+        if len(config_overrides) > 0:
+            config.parse_known_args(config_overrides, relaxed_parser=True)
+    else:
+        msg = "You need to specify either --config_path or --continue_path"
+        raise RuntimeError(msg)
 
     # load training samples
     train_samples, eval_samples = load_tts_samples(

--- a/TTS/bin/train_vocoder.py
+++ b/TTS/bin/train_vocoder.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 
 from trainer import Trainer, TrainerArgs
 
-from TTS.config import load_config, register_config
+from TTS.config import load_config
 from TTS.utils.audio import AudioProcessor
 from TTS.utils.generic_utils import ConsoleFormatter, setup_logger
 from TTS.vocoder.datasets.preprocess import load_wav_data, load_wav_feat_data
@@ -14,7 +14,7 @@ from TTS.vocoder.models import setup_model
 
 @dataclass
 class TrainVocoderArgs(TrainerArgs):
-    config_path: str = field(default=None, metadata={"help": "Path to the config file."})
+    config_path: str | None = field(default=None, metadata={"help": "Path to the config file."})
 
 
 def main(arg_list: list[str] | None = None):
@@ -29,25 +29,20 @@ def main(arg_list: list[str] | None = None):
     args, config_overrides = parser.parse_known_args(arg_list)
     train_args.parse_args(args)
 
-    # load config.json and register
-    if args.config_path or args.continue_path:
-        if args.config_path:
-            # init from a file
-            config = load_config(args.config_path)
-            if len(config_overrides) > 0:
-                config.parse_known_args(config_overrides, relaxed_parser=True)
-        elif args.continue_path:
-            # continue from a prev experiment
-            config = load_config(os.path.join(args.continue_path, "config.json"))
-            if len(config_overrides) > 0:
-                config.parse_known_args(config_overrides, relaxed_parser=True)
-        else:
-            # init from console args
-            from TTS.config.shared_configs import BaseTrainingConfig  # pylint: disable=import-outside-toplevel
-
-            config_base = BaseTrainingConfig()
-            config_base.parse_known_args(config_overrides)
-            config = register_config(config_base.model)()
+    # load config.json
+    if args.config_path:
+        # init from a file
+        config = load_config(args.config_path)
+        if len(config_overrides) > 0:
+            config.parse_known_args(config_overrides, relaxed_parser=True)
+    elif args.continue_path:
+        # continue from a prev experiment
+        config = load_config(os.path.join(args.continue_path, "config.json"))
+        if len(config_overrides) > 0:
+            config.parse_known_args(config_overrides, relaxed_parser=True)
+    else:
+        msg = "You need to specify either --config_path or --continue_path"
+        raise RuntimeError(msg)
 
     # load training samples
     if "feature_path" in config and config.feature_path:

--- a/TTS/tts/configs/shared_configs.py
+++ b/TTS/tts/configs/shared_configs.py
@@ -334,7 +334,7 @@ class BaseTTSConfig(BaseTrainingConfig):
     shuffle: bool = False
     drop_last: bool = False
     # dataset
-    datasets: list[BaseDatasetConfig] = field(default_factory=lambda: [BaseDatasetConfig()])
+    datasets: list[BaseDatasetConfig] = field(default_factory=list)
     # optimizer
     optimizer: str = "radam"
     optimizer_params: dict = None

--- a/TTS/tts/layers/bark/inference_funcs.py
+++ b/TTS/tts/layers/bark/inference_funcs.py
@@ -451,13 +451,3 @@ def generate_fine(
     assert gen_fine_arr.shape[-1] == x_coarse_gen.shape[-1]
     clear_cuda_cache()
     return gen_fine_arr
-
-
-@torch.inference_mode()
-def codec_decode(fine_tokens: torch.Tensor, model) -> torch.Tensor:
-    """Turn quantized audio codes into audio array using encodec."""
-    arr = fine_tokens.unsqueeze(0)
-    arr = arr.transpose(0, 1)
-    emb = model.encodec.quantizer.decode(arr)
-    out = model.encodec.decoder(emb)
-    return out.squeeze().cpu()

--- a/TTS/tts/models/bark.py
+++ b/TTS/tts/models/bark.py
@@ -9,16 +9,13 @@ import numpy as np
 import torch
 import torchaudio
 from coqpit import Coqpit
-from encodec import EncodecModel
-from encodec.utils import convert_audio
-from transformers import BertTokenizer
+from transformers import AutoProcessor, BertTokenizer, EncodecModel
 
 from TTS.tts.configs.shared_configs import BaseTTSConfig
 from TTS.tts.layers.bark.hubert.hubert_manager import HubertManager
 from TTS.tts.layers.bark.hubert.kmeans_hubert import CustomHubert
 from TTS.tts.layers.bark.hubert.tokenizer import HubertTokenizer
 from TTS.tts.layers.bark.inference_funcs import (
-    codec_decode,
     generate_coarse,
     generate_fine,
     generate_text_semantic,
@@ -55,8 +52,9 @@ class Bark(BaseTTS):
         self.semantic_model = GPT(config.semantic_config)
         self.coarse_model = GPT(config.coarse_config)
         self.fine_model = FineGPT(config.fine_config)
-        self.encodec = EncodecModel.encodec_model_24khz()
-        self.encodec.set_target_bandwidth(6.0)
+        self.encodec = EncodecModel.from_pretrained("facebook/encodec_24khz")
+        self.processor = AutoProcessor.from_pretrained("facebook/encodec_24khz")
+        self.encodec_bandwidth = 6.0
 
     def load_bark_models(self):
         self.semantic_model, self.config = load_model(
@@ -105,6 +103,15 @@ class Bark(BaseTTS):
         )
         return x_semantic
 
+    @torch.inference_mode()
+    def codec_decode(self, fine_tokens: torch.Tensor) -> torch.Tensor:
+        """Turn quantized audio codes into audio array using encodec."""
+        arr = fine_tokens.unsqueeze(0)
+        arr = arr.transpose(0, 1)
+        emb = self.encodec.quantizer.decode(arr)
+        out = self.encodec.decoder(emb)
+        return out.squeeze().cpu()
+
     def semantic_to_waveform(
         self,
         semantic_tokens: torch.Tensor,
@@ -136,7 +143,7 @@ class Bark(BaseTTS):
             temp=0.5,
             base=base,
         )
-        audio_arr = codec_decode(x_fine_gen, self)
+        audio_arr = self.codec_decode(x_fine_gen)
         return audio_arr, x_coarse_gen, x_fine_gen
 
     def generate_audio(
@@ -176,18 +183,15 @@ class Bark(BaseTTS):
     def _generate_voice(self, speaker_wav: str | os.PathLike[Any]) -> dict[str, torch.Tensor]:
         """Generate a new voice from the given audio."""
         audio, sr = torchaudio.load(speaker_wav)
-        audio = convert_audio(audio, sr, self.config.sample_rate, self.encodec.channels)
-        audio = audio.unsqueeze(0).to(self.device)
+        audio = torchaudio.transforms.Resample(sr, self.config.sample_rate)(audio).to(self.device)
 
-        with torch.inference_mode():
-            encoded_frames = self.encodec.encode(audio)
-        codes = torch.cat([encoded[0] for encoded in encoded_frames], dim=-1).squeeze()  # [n_q, T]
+        inputs = self.processor(raw_audio=audio.squeeze(0), sampling_rate=self.config.sample_rate, return_tensors="pt")
+        codes = self.encodec.encode(inputs["input_values"], inputs["padding_mask"], self.encodec_bandwidth)[0][0, 0]
 
         # generate semantic tokens
         # Load the HuBERT model
         hubert_manager = HubertManager()
         hubert_manager.make_sure_tokenizer_installed(model_path=self.config.LOCAL_MODEL_PATHS["hubert_tokenizer"])
-
         hubert_model = CustomHubert().to(self.device)
 
         # Load the CustomTokenizer model
@@ -198,7 +202,7 @@ class Bark(BaseTTS):
         #     text, max_gen_duration_s=seconds, top_k=50, top_p=0.95, temp=0.7
         # )  # not 100%
         with torch.inference_mode():
-            semantic_vectors = hubert_model.forward(audio[0], input_sample_hz=self.config.sample_rate)
+            semantic_vectors = hubert_model.forward(audio, input_sample_hz=self.config.sample_rate)
         semantic_tokens = tokenizer.get_token(semantic_vectors)
         return {
             "semantic_prompt": semantic_tokens,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,6 @@ dependencies = [
     # Tortoise
     "einops>=0.6.0",
     "transformers>=4.57",
-    # Bark
-    "encodec>=0.1.1",
     # XTTS
     "num2words>=0.5.14",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,6 @@ dependencies = [
     # Core
     "numpy>=1.26.0",
     "scipy>=1.13.0",
-    "torch>=2.2",
-    "torchaudio>=2.2.0",
     "soundfile>=0.12.0",
     "librosa>=0.11.0",
     "numba>=0.58.0",
@@ -92,8 +90,19 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+cpu = [
+    "torch>=2.2",
+    "torchaudio>=2.2.0",
+]
+cuda = [
+    "torch>=2.2",
+    "torchaudio>=2.2.0",
+]
 # torchcodec needed from torch>=2.9
 codec = [
+    "torchcodec>=0.8.0",
+]
+codec-cuda = [
     "torchcodec>=0.8.0",
 ]
 # Only used in notebooks
@@ -135,6 +144,46 @@ languages = [
 all = [
     "coqui-tts[codec,notebooks,server,bn,ja,ko,zh]",
 ]
+
+[tool.uv]
+required-environments = [
+    "sys_platform == 'linux' and platform_machine == 'x86_64'"
+]
+conflicts = [
+  [
+    { extra = "cpu" },
+    { extra = "cuda" },
+  ],
+  [
+    { extra = "codec" },
+    { extra = "codec-cuda" },
+  ],
+]
+
+[tool.uv.sources]
+torch = [
+  { index = "pytorch-cpu", extra = "cpu" },
+  { index = "pytorch-cuda", extra = "cuda" },
+]
+torchaudio = [
+  { index = "pytorch-cpu", extra = "cpu" },
+  { index = "pytorch-cuda", extra = "cuda" },
+]
+torchcodec = [
+  { index = "pytorch-cpu", extra = "codec" },
+  { index = "pytorch-cuda", extra = "codec-cuda" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cuda"
+url = "https://download.pytorch.org/whl/cu128"
+explicit = true
+
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     "matplotlib>=3.8.4",
     # Coqui stack
     "coqui-tts-trainer>=0.3.0,<0.4.0",
-    "coqpit-config>=0.2.0,<0.3.0",
+    "coqpit-config>=0.2.3,<0.3.0",
     "monotonic-alignment-search>=0.1.0",
     "ko-speech-tools>=0.1.0",
     # Gruut + supported languages

--- a/recipes/ljspeech/fast_pitch/train_fast_pitch.py
+++ b/recipes/ljspeech/fast_pitch/train_fast_pitch.py
@@ -2,10 +2,11 @@ import os
 
 from trainer import Trainer, TrainerArgs
 
+from TTS.bin.compute_attention_masks import compute_attention_masks
 from TTS.config.shared_configs import BaseAudioConfig, BaseDatasetConfig
 from TTS.tts.configs.fast_pitch_config import FastPitchConfig
 from TTS.tts.datasets import load_tts_samples
-from TTS.tts.models.forward_tts import ForwardTTS
+from TTS.tts.models.forward_tts import ForwardTTS, ForwardTTSArgs
 from TTS.tts.utils.text.tokenizer import TTSTokenizer
 from TTS.utils.audio import AudioProcessor
 from TTS.utils.manage import ModelManager
@@ -14,11 +15,13 @@ output_path = os.path.dirname(os.path.abspath(__file__))
 
 
 def main():
+    use_aligner = True  # learned alignments
+
     # init configs
     dataset_config = BaseDatasetConfig(
         formatter="ljspeech",
         meta_file_train="metadata.csv",
-        # meta_file_attn_mask=os.path.join(output_path, "../LJSpeech-1.1/metadata_attn_mask.txt"),
+        meta_file_attn_mask=os.path.join(output_path, "../LJSpeech-1.1/metadata_attn_mask.txt") if use_aligner else "",
         path=os.path.join(output_path, "../LJSpeech-1.1/"),
     )
 
@@ -37,6 +40,7 @@ def main():
 
     config = FastPitchConfig(
         run_name="fast_pitch_ljspeech",
+        model_args=ForwardTTSArgs(use_aligner=use_aligner),
         audio=audio_config,
         batch_size=32,
         eval_batch_size=16,
@@ -62,13 +66,10 @@ def main():
     )
 
     # compute alignments
-    if not config.model_args.use_aligner:
+    if not use_aligner:
         manager = ModelManager()
         model_path, config_path, _ = manager.download_model("tts_models/en/ljspeech/tacotron2-DCA")
-        # TODO: make compute_attention python callable
-        os.system(
-            f"python TTS/bin/compute_attention_masks.py --model_path {model_path} --config_path {config_path} --dataset ljspeech --dataset_metafile metadata.csv --data_path ./recipes/ljspeech/LJSpeech-1.1/  --use_cuda"
-        )
+        compute_attention_masks(model_path, config_path, "recipes/ljspeech/LJSpeech-1.1")
 
     # INITIALIZE THE AUDIO PROCESSOR
     # Audio processor is used for feature extraction and audio I/O.

--- a/recipes/ljspeech/fast_speech/train_fast_speech.py
+++ b/recipes/ljspeech/fast_speech/train_fast_speech.py
@@ -2,10 +2,11 @@ import os
 
 from trainer import Trainer, TrainerArgs
 
+from TTS.bin.compute_attention_masks import compute_attention_masks
 from TTS.config import BaseAudioConfig, BaseDatasetConfig
 from TTS.tts.configs.fast_speech_config import FastSpeechConfig
 from TTS.tts.datasets import load_tts_samples
-from TTS.tts.models.forward_tts import ForwardTTS
+from TTS.tts.models.forward_tts import ForwardTTS, ForwardTTSArgs
 from TTS.tts.utils.text.tokenizer import TTSTokenizer
 from TTS.utils.audio import AudioProcessor
 from TTS.utils.manage import ModelManager
@@ -14,11 +15,13 @@ output_path = os.path.dirname(os.path.abspath(__file__))
 
 
 def main():
+    use_aligner = True  # learned alignments
+
     # init configs
     dataset_config = BaseDatasetConfig(
         formatter="ljspeech",
         meta_file_train="metadata.csv",
-        # meta_file_attn_mask=os.path.join(output_path, "../LJSpeech-1.1/metadata_attn_mask.txt"),
+        meta_file_attn_mask=os.path.join(output_path, "../LJSpeech-1.1/metadata_attn_mask.txt") if use_aligner else "",
         path=os.path.join(output_path, "../LJSpeech-1.1/"),
     )
 
@@ -37,6 +40,7 @@ def main():
 
     config = FastSpeechConfig(
         run_name="fast_speech_ljspeech",
+        model_args=ForwardTTSArgs(use_aligner=use_aligner),
         audio=audio_config,
         batch_size=32,
         eval_batch_size=16,
@@ -61,13 +65,10 @@ def main():
     )
 
     # compute alignments
-    if not config.model_args.use_aligner:
+    if not use_aligner:
         manager = ModelManager()
         model_path, config_path, _ = manager.download_model("tts_models/en/ljspeech/tacotron2-DCA")
-        # TODO: make compute_attention python callable
-        os.system(
-            f"python TTS/bin/compute_attention_masks.py --model_path {model_path} --config_path {config_path} --dataset ljspeech --dataset_metafile metadata.csv --data_path ./recipes/ljspeech/LJSpeech-1.1/  --use_cuda"
-        )
+        compute_attention_masks(model_path, config_path, "recipes/ljspeech/LJSpeech-1.1")
 
     # INITIALIZE THE AUDIO PROCESSOR
     # Audio processor is used for feature extraction and audio I/O.

--- a/recipes/ljspeech/fastspeech2/train_fastspeech2.py
+++ b/recipes/ljspeech/fastspeech2/train_fastspeech2.py
@@ -2,10 +2,11 @@ import os
 
 from trainer import Trainer, TrainerArgs
 
+from TTS.bin.compute_attention_masks import compute_attention_masks
 from TTS.config.shared_configs import BaseAudioConfig, BaseDatasetConfig
 from TTS.tts.configs.fastspeech2_config import Fastspeech2Config
 from TTS.tts.datasets import load_tts_samples
-from TTS.tts.models.forward_tts import ForwardTTS
+from TTS.tts.models.forward_tts import ForwardTTS, ForwardTTSArgs
 from TTS.tts.utils.text.tokenizer import TTSTokenizer
 from TTS.utils.audio import AudioProcessor
 from TTS.utils.manage import ModelManager
@@ -14,11 +15,13 @@ output_path = os.path.dirname(os.path.abspath(__file__))
 
 
 def main():
+    use_aligner = True  # learned alignments
+
     # init configs
     dataset_config = BaseDatasetConfig(
         formatter="ljspeech",
         meta_file_train="metadata.csv",
-        # meta_file_attn_mask=os.path.join(output_path, "../LJSpeech-1.1/metadata_attn_mask.txt"),
+        meta_file_attn_mask=os.path.join(output_path, "../LJSpeech-1.1/metadata_attn_mask.txt") if use_aligner else "",
         path=os.path.join(output_path, "../LJSpeech-1.1/"),
     )
 
@@ -37,6 +40,7 @@ def main():
 
     config = Fastspeech2Config(
         run_name="fastspeech2_ljspeech",
+        model_args=ForwardTTSArgs(use_aligner=use_aligner),
         audio=audio_config,
         batch_size=32,
         eval_batch_size=16,
@@ -64,13 +68,10 @@ def main():
     )
 
     # compute alignments
-    if not config.model_args.use_aligner:
+    if not use_aligner:
         manager = ModelManager()
         model_path, config_path, _ = manager.download_model("tts_models/en/ljspeech/tacotron2-DCA")
-        # TODO: make compute_attention python callable
-        os.system(
-            f"python TTS/bin/compute_attention_masks.py --model_path {model_path} --config_path {config_path} --dataset ljspeech --dataset_metafile metadata.csv --data_path ./recipes/ljspeech/LJSpeech-1.1/  --use_cuda"
-        )
+        compute_attention_masks(model_path, config_path, "recipes/ljspeech/LJSpeech-1.1")
 
     # INITIALIZE THE AUDIO PROCESSOR
     # Audio processor is used for feature extraction and audio I/O.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+import torch
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_seed() -> None:
+    """Set random seed for reproducibility across all tests."""
+    torch.manual_seed(1)
+
+
+@pytest.fixture(scope="session")
+def device() -> torch.device:
+    """Provide torch device (CUDA if available, otherwise CPU)."""
+    return torch.device("cuda:0" if torch.cuda.is_available() else "cpu")

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -9,6 +9,7 @@ from trainer.io import get_last_checkpoint
 from tests import run_main
 from TTS.bin.synthesize import main as synthesize
 from TTS.bin.train_tts import main as train_tts
+from TTS.config.shared_configs import BaseDatasetConfig
 from TTS.tts.configs.shared_configs import BaseTTSConfig
 from TTS.vc.configs.shared_configs import BaseVCConfig
 
@@ -61,13 +62,23 @@ def run_tts_train(tmp_path: Path, config: BaseTTSConfig):
     torch.save({"mean": -5.5138, "std": 2.0636, "init_transition_prob": 0.3212}, parameter_path)
     config.mel_statistics_parameter_path = parameter_path
 
+    is_multi_speaker = config.use_speaker_embedding or config.use_d_vector_file
+    formatter = "ljspeech_test" if is_multi_speaker else "ljspeech"
+
+    config.datasets.append(
+        BaseDatasetConfig(
+            formatter=formatter,
+            meta_file_train="metadata.csv",
+            path="tests/data/ljspeech",
+            meta_file_attn_mask="tests/data/ljspeech/metadata_attn_mask.txt",
+        )
+    )
+
     config.audio.do_trim_silence = True
     config.audio.trim_db = 60
     config.save_json(config_path)
 
     # train the model for one epoch
-    is_multi_speaker = config.use_speaker_embedding or config.use_d_vector_file
-    formatter = "ljspeech_test" if is_multi_speaker else "ljspeech"
     command_train = [
         "--config_path",
         str(config_path),
@@ -75,18 +86,10 @@ def run_tts_train(tmp_path: Path, config: BaseTTSConfig):
         str(output_path),
         "--coqpit.phoneme_cache_path",
         str(output_path / "phoneme_cache"),
-        "--coqpit.datasets.0.formatter",
-        formatter,
-        "--coqpit.datasets.0.meta_file_train",
-        "metadata.csv",
         "--coqpit.datasets.0.meta_file_val",
         "metadata.csv",
-        "--coqpit.datasets.0.path",
-        "tests/data/ljspeech",
         "--coqpit.test_delay_epochs",
         "0",
-        "--coqpit.datasets.0.meta_file_attn_mask",
-        "tests/data/ljspeech/metadata_attn_mask.txt",
     ]
     run_main(train_tts, command_train)
 

--- a/tests/integration/test_tacotron.py
+++ b/tests/integration/test_tacotron.py
@@ -13,10 +13,6 @@ from TTS.tts.layers.losses import L1LossMasked
 from TTS.tts.models.tacotron import Tacotron
 from TTS.utils.audio import AudioProcessor
 
-torch.manual_seed(1)
-use_cuda = torch.cuda.is_available()
-device = torch.device("cuda" if use_cuda else "cpu")
-
 WAV_FILE = os.path.join(get_tests_input_path(), "example_1.wav")
 
 
@@ -26,7 +22,7 @@ def base_config():
     return TacotronConfig(num_chars=32, num_speakers=5, out_channels=513, decoder_output_dim=80)
 
 
-def create_tacotron_inputs(config, batch_size=8, max_seq_len=128, max_mel_len=30):
+def create_tacotron_inputs(config, device: torch.device, batch_size=8, max_seq_len=128, max_mel_len=30):
     """Create input tensors for Tacotron training."""
     input_dummy = torch.randint(0, 24, (batch_size, max_seq_len)).long().to(device)
     input_lengths = torch.randint(100, max_seq_len + 1, (batch_size,)).long().to(device)
@@ -38,7 +34,7 @@ def create_tacotron_inputs(config, batch_size=8, max_seq_len=128, max_mel_len=30
     return input_dummy, input_lengths, mel_spec, linear_spec, mel_lengths
 
 
-def create_stop_targets(mel_lengths, batch_size, mel_len, r):
+def create_stop_targets(mel_lengths, batch_size, mel_len, r, device: torch.device):
     """Create stop targets for Tacotron training."""
     stop_targets = torch.zeros(batch_size, mel_len, 1).float().to(device)
     for idx in mel_lengths:
@@ -48,7 +44,9 @@ def create_stop_targets(mel_lengths, batch_size, mel_len, r):
     return stop_targets
 
 
-def train_and_verify_updates(config, aux_input=None, num_iterations=5, ignore_params=None, print_params=True):
+def train_and_verify_updates(
+    config, device: torch.device, aux_input=None, num_iterations=5, ignore_params=None, print_params=True
+):
     """Train Tacotron model and verify parameters are updated."""
     criterion = L1LossMasked(seq_len_norm=False).to(device)
     criterion_st = nn.BCEWithLogitsLoss().to(device)
@@ -60,8 +58,8 @@ def train_and_verify_updates(config, aux_input=None, num_iterations=5, ignore_pa
     assert_parameters_equal(model, model_ref)
     optimizer = optim.Adam(model.parameters(), lr=config.lr)
     for _ in range(num_iterations):
-        input_dummy, input_lengths, mel_spec, linear_spec, mel_lengths = create_tacotron_inputs(config)
-        stop_targets = create_stop_targets(mel_lengths, 8, 30, config.r)
+        input_dummy, input_lengths, mel_spec, linear_spec, mel_lengths = create_tacotron_inputs(config, device)
+        stop_targets = create_stop_targets(mel_lengths, 8, 30, config.r, device)
         outputs = model.forward(input_dummy, input_lengths, mel_spec, mel_lengths, aux_input=aux_input)
         optimizer.zero_grad()
         loss = criterion(outputs["decoder_outputs"], mel_spec, mel_lengths)
@@ -72,15 +70,15 @@ def train_and_verify_updates(config, aux_input=None, num_iterations=5, ignore_pa
     assert_parameters_change(model, model_ref, ignore=ignore_params)
 
 
-def test_train_step(base_config):
+def test_train_step(base_config, device: torch.device):
     """Test vanilla Tacotron training."""
     config = base_config.copy()
     config.use_speaker_embedding = False
     config.num_speakers = 1
-    train_and_verify_updates(config)
+    train_and_verify_updates(config, device)
 
 
-def test_multispeaker_train_step(base_config):
+def test_multispeaker_train_step(base_config, device: torch.device):
     """Test multi-speaker Tacotron with speaker embeddings."""
     config = base_config.copy()
     config.use_speaker_embedding = True
@@ -88,10 +86,10 @@ def test_multispeaker_train_step(base_config):
     config.d_vector_dim = 55
 
     speaker_ids = torch.randint(0, 5, (8,)).long().to(device)
-    train_and_verify_updates(config, aux_input={"speaker_ids": speaker_ids})
+    train_and_verify_updates(config, device, aux_input={"speaker_ids": speaker_ids})
 
 
-def test_gst_train_step_random(base_config):
+def test_gst_train_step_random(base_config, device: torch.device):
     """Test Tacotron with Global Style Tokens using random mel style."""
     config = base_config.copy()
     config.use_speaker_embedding = True
@@ -102,13 +100,14 @@ def test_gst_train_step_random(base_config):
     speaker_ids = torch.randint(0, 5, (8,)).long().to(device)
     train_and_verify_updates(
         config,
+        device,
         aux_input={"speaker_ids": speaker_ids},
         num_iterations=10,
         ignore_params=["gst_layer.encoder.recurrence.weight_hh_l0"],
     )
 
 
-def test_gst_train_step_file(base_config):
+def test_gst_train_step_file(base_config, device: torch.device):
     """Test Tacotron with Global Style Tokens using mel from file."""
     config = base_config.copy()
     config.use_speaker_embedding = True
@@ -139,7 +138,7 @@ def test_gst_train_step_file(base_config):
         linear_spec = torch.rand(8, mel_len, config.audio["fft_size"] // 2 + 1).to(device)
         mel_lengths = torch.randint(20, mel_len, (8,)).long().to(device)
         mel_lengths[-1] = mel_len
-        stop_targets = create_stop_targets(mel_lengths, 8, mel_len, config.r)
+        stop_targets = create_stop_targets(mel_lengths, 8, mel_len, config.r, device)
         speaker_ids = torch.randint(0, 5, (8,)).long().to(device)
 
         outputs = model.forward(
@@ -154,7 +153,7 @@ def test_gst_train_step_file(base_config):
     assert_parameters_change(model, model_ref, ignore=["gst_layer.encoder.recurrence.weight_hh_l0"])
 
 
-def test_capacitron_train_step():
+def test_capacitron_train_step(device: torch.device):
     """Test Tacotron with Capacitron VAE."""
     config = TacotronConfig(
         num_chars=32,
@@ -210,7 +209,7 @@ def test_capacitron_train_step():
     assert_parameters_change(model, model_ref)
 
 
-def test_scgst_multispeaker_train_step(base_config):
+def test_scgst_multispeaker_train_step(base_config, device: torch.device):
     """Test multi-speaker Tacotron with Global Style Tokens and d-vectors."""
     config = base_config.copy()
     config.use_d_vector_file = True
@@ -221,6 +220,7 @@ def test_scgst_multispeaker_train_step(base_config):
     speaker_embeddings = torch.rand(8, 55).to(device)
     train_and_verify_updates(
         config,
+        device,
         aux_input={"d_vectors": speaker_embeddings},
         ignore_params=["gst_layer.encoder.recurrence.weight_hh_l0"],
     )

--- a/tests/integration/test_tacotron2.py
+++ b/tests/integration/test_tacotron2.py
@@ -13,10 +13,6 @@ from TTS.tts.layers.losses import MSELossMasked
 from TTS.tts.models.tacotron2 import Tacotron2
 from TTS.utils.audio import AudioProcessor
 
-torch.manual_seed(1)
-use_cuda = torch.cuda.is_available()
-device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-
 WAV_FILE = os.path.join(get_tests_input_path(), "example_1.wav")
 
 
@@ -26,7 +22,7 @@ def base_config():
     return Tacotron2Config(num_chars=32, num_speakers=5, out_channels=80, decoder_output_dim=80)
 
 
-def create_tacotron2_inputs(config, batch_size=8, max_seq_len=128, max_mel_len=30):
+def create_tacotron2_inputs(config, device: torch.device, batch_size=8, max_seq_len=128, max_mel_len=30):
     """Create input tensors for Tacotron2 training."""
     input_dummy = torch.randint(0, 24, (batch_size, max_seq_len)).long().to(device)
     input_lengths = torch.randint(100, max_seq_len, (batch_size,)).long().to(device)
@@ -38,7 +34,7 @@ def create_tacotron2_inputs(config, batch_size=8, max_seq_len=128, max_mel_len=3
     return input_dummy, input_lengths, mel_spec, mel_postnet_spec, mel_lengths
 
 
-def train_and_verify_updates(config, aux_input=None, num_iterations=5, ignore_params=None):
+def train_and_verify_updates(config, device: torch.device, aux_input=None, num_iterations=5, ignore_params=None):
     """Train Tacotron2 model and verify parameters are updated."""
     criterion = MSELossMasked(seq_len_norm=False).to(device)
     criterion_st = nn.BCEWithLogitsLoss().to(device)
@@ -48,8 +44,8 @@ def train_and_verify_updates(config, aux_input=None, num_iterations=5, ignore_pa
     assert_parameters_equal(model, model_ref)
     optimizer = optim.Adam(model.parameters(), lr=config.lr)
     for _ in range(num_iterations):
-        input_dummy, input_lengths, mel_spec, mel_postnet_spec, mel_lengths = create_tacotron2_inputs(config)
-        stop_targets = create_stop_targets(mel_lengths, 8, 30, config.r)
+        input_dummy, input_lengths, mel_spec, mel_postnet_spec, mel_lengths = create_tacotron2_inputs(config, device)
+        stop_targets = create_stop_targets(mel_lengths, 8, 30, config.r, device)
         outputs = model.forward(input_dummy, input_lengths, mel_spec, mel_lengths, aux_input=aux_input)
         assert torch.sigmoid(outputs["stop_tokens"]).data.max() <= 1.0
         assert torch.sigmoid(outputs["stop_tokens"]).data.min() >= 0.0
@@ -62,15 +58,15 @@ def train_and_verify_updates(config, aux_input=None, num_iterations=5, ignore_pa
     assert_parameters_change(model, model_ref, ignore=ignore_params)
 
 
-def test_train_step(base_config):
+def test_train_step(base_config, device: torch.device):
     """Test vanilla Tacotron2 model."""
     config = base_config.copy()
     config.use_speaker_embedding = False
     config.num_speakers = 1
-    train_and_verify_updates(config)
+    train_and_verify_updates(config, device)
 
 
-def test_multispeaker_train_step(base_config):
+def test_multispeaker_train_step(base_config, device: torch.device):
     """Test multi-speaker Tacotron2 with speaker embedding layer."""
     config = base_config.copy()
     config.use_speaker_embedding = True
@@ -78,10 +74,10 @@ def test_multispeaker_train_step(base_config):
     config.d_vector_dim = 55
 
     speaker_ids = torch.randint(0, 5, (8,)).long().to(device)
-    train_and_verify_updates(config, aux_input={"speaker_ids": speaker_ids})
+    train_and_verify_updates(config, device, aux_input={"speaker_ids": speaker_ids})
 
 
-def test_gst_train_step_random(base_config):
+def test_gst_train_step_random(base_config, device: torch.device):
     """Test multi-speaker Tacotron2 with Global Style Token and Speaker Embedding using random mel."""
     config = base_config.copy()
     config.use_speaker_embedding = True
@@ -92,13 +88,14 @@ def test_gst_train_step_random(base_config):
     speaker_ids = torch.randint(0, 5, (8,)).long().to(device)
     train_and_verify_updates(
         config,
+        device,
         aux_input={"speaker_ids": speaker_ids},
         num_iterations=10,
         ignore_params=["gst_layer.encoder.recurrence.weight_hh_l0"],
     )
 
 
-def test_gst_train_step_file(base_config):
+def test_gst_train_step_file(base_config, device: torch.device):
     """Test multi-speaker Tacotron2 with Global Style Token using mel from file."""
     config = base_config.copy()
     config.use_speaker_embedding = True
@@ -127,7 +124,7 @@ def test_gst_train_step_file(base_config):
         mel_postnet_spec = torch.rand(8, 30, config.audio["num_mels"]).to(device)
         mel_lengths = torch.randint(20, 30, (8,)).long().to(device)
         mel_lengths[0] = 30
-        stop_targets = create_stop_targets(mel_lengths, 8, 30, config.r)
+        stop_targets = create_stop_targets(mel_lengths, 8, 30, config.r, device)
         speaker_ids = torch.randint(0, 5, (8,)).long().to(device)
 
         outputs = model.forward(
@@ -144,7 +141,7 @@ def test_gst_train_step_file(base_config):
     assert_parameters_change(model, model_ref, ignore=["gst_layer.encoder.recurrence.weight_hh_l0"])
 
 
-def test_capacitron_train_step():
+def test_capacitron_train_step(device: torch.device):
     """Test Tacotron2 with Capacitron VAE."""
     config = Tacotron2Config(
         num_chars=32,
@@ -200,7 +197,7 @@ def test_capacitron_train_step():
     assert_parameters_change(model, model_ref)
 
 
-def test_scgst_multispeaker_train_step(base_config):
+def test_scgst_multispeaker_train_step(base_config, device: torch.device):
     """Test multi-speaker Tacotron2 with Global Style Tokens and d-vector inputs."""
     config = base_config.copy()
     config.use_d_vector_file = True
@@ -211,6 +208,7 @@ def test_scgst_multispeaker_train_step(base_config):
     speaker_embeddings = torch.rand(8, 55).to(device)
     train_and_verify_updates(
         config,
+        device,
         aux_input={"d_vectors": speaker_embeddings},
         ignore_params=["gst_layer.encoder.recurrence.weight_hh_l0"],
     )

--- a/tests/tts_tests/test_delightful_tts_layers.py
+++ b/tests/tts_tests/test_delightful_tts_layers.py
@@ -7,8 +7,6 @@ from TTS.tts.utils.helpers import rand_segments
 from TTS.tts.utils.text.tokenizer import TTSTokenizer
 from TTS.vocoder.models.hifigan_generator import HifiganGenerator
 
-device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-
 args = DelightfulTtsArgs()
 v_args = VocoderConfig()
 
@@ -26,7 +24,7 @@ config = DelightfulTTSConfig(
 tokenizer, config = TTSTokenizer.init_from_config(config)
 
 
-def test_acoustic_model():
+def test_acoustic_model(device):
     dummy_tokens = torch.rand((1, 41)).long().to(device)
     dummy_text_lens = torch.tensor([41]).long().to(device)
     dummy_spec = torch.rand((1, 100, 207)).to(device)
@@ -55,7 +53,7 @@ def test_acoustic_model():
     # output["model_outputs"].sum().backward()
 
 
-def test_hifi_decoder():
+def test_hifi_decoder(device):
     dummy_input = torch.rand((1, 207, 100)).to(device)
     dummy_spec_lens = torch.tensor([207]).to(device)
 

--- a/tests/tts_tests/test_feed_forward_layers.py
+++ b/tests/tts_tests/test_feed_forward_layers.py
@@ -4,10 +4,8 @@ from TTS.tts.layers.feed_forward.decoder import Decoder
 from TTS.tts.layers.feed_forward.encoder import Encoder
 from TTS.tts.utils.helpers import sequence_mask
 
-device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
-
-def test_encoder():
+def test_encoder(device):
     input_dummy = torch.rand(8, 14, 37).to(device)
     input_lengths = torch.randint(31, 37, (8,)).long().to(device)
     input_lengths[-1] = 37
@@ -49,7 +47,7 @@ def test_encoder():
     assert list(output.shape) == [8, 14, 37]
 
 
-def test_decoder():
+def test_decoder(device):
     input_dummy = torch.rand(8, 128, 37).to(device)
     input_lengths = torch.randint(31, 37, (8,)).long().to(device)
     input_lengths[-1] = 37

--- a/tests/tts_tests/test_overflow.py
+++ b/tests/tts_tests/test_overflow.py
@@ -14,12 +14,6 @@ from TTS.tts.utils.helpers import sequence_mask
 
 
 @pytest.fixture(scope="session")
-def device():
-    """Get torch device for testing."""
-    return torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-
-
-@pytest.fixture(scope="session")
 def parameter_path() -> Path:
     """Create and return path to test parameters."""
     path = Path(get_tests_output_path()) / "lj_parameters.pt"
@@ -63,12 +57,6 @@ def get_overflow_model(config, parameter_path, device):
         return model.to(device)
 
     return _get_model
-
-
-@pytest.fixture(autouse=True)
-def set_random_seed():
-    """Set random seed for reproducibility."""
-    torch.manual_seed(1)
 
 
 # Tests for Overflow model

--- a/tests/vocoder_tests/test_wavegrad.py
+++ b/tests/vocoder_tests/test_wavegrad.py
@@ -5,13 +5,8 @@ from torch import optim
 from TTS.vocoder.configs import WavegradConfig
 from TTS.vocoder.models.wavegrad import Wavegrad, WavegradArgs
 
-# pylint: disable=unused-variable
 
-torch.manual_seed(1)
-device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-
-
-def test_train_step():
+def test_train_step(device: torch.device):
     """Test if all layers are updated in a basic training cycle"""
     torch.set_grad_enabled(True)
     input_dummy = torch.rand(8, 1, 20 * 300).to(device)

--- a/tests/zoo_tests/test_big_models.py
+++ b/tests/zoo_tests/test_big_models.py
@@ -45,7 +45,7 @@ def test_xtts(tmp_path):
 
 
 @pytest.mark.skipif(GITHUB_ACTIONS, reason="Model too big for CI")
-def test_xtts_streaming(manager):
+def test_xtts_streaming(manager, device: torch.device):
     """Testing the new inference_stream method"""
     from TTS.tts.configs.xtts_config import XttsConfig
     from TTS.tts.models.xtts import Xtts
@@ -58,7 +58,7 @@ def test_xtts_streaming(manager):
     config.load_json(model_path / "config.json")
     model = Xtts.init_from_config(config)
     model.load_checkpoint(config, checkpoint_dir=str(model_path))
-    model.to(torch.device("cuda" if torch.cuda.is_available() else "cpu"))
+    model.to(device)
 
     print("Computing speaker latents...")
     gpt_cond_latent, speaker_embedding = model.get_conditioning_latents(audio_path=speaker_wav)
@@ -101,7 +101,7 @@ def test_xtts_v2(tmp_path):
 
 
 @pytest.mark.skipif(GITHUB_ACTIONS, reason="Model too big for CI")
-def test_xtts_v2_streaming(manager):
+def test_xtts_v2_streaming(manager, device: torch.device):
     """Testing the new inference_stream method"""
     from TTS.tts.configs.xtts_config import XttsConfig
     from TTS.tts.models.xtts import Xtts
@@ -112,7 +112,7 @@ def test_xtts_v2_streaming(manager):
     config.load_json(model_path / "config.json")
     model = Xtts.init_from_config(config)
     model.load_checkpoint(config, checkpoint_dir=str(model_path))
-    model.to(torch.device("cuda" if torch.cuda.is_available() else "cpu"))
+    model.to(device)
 
     print("Computing speaker latents...")
     gpt_cond_latent, speaker_embedding = model.get_conditioning_latents(audio_path=speaker_wav)


### PR DESCRIPTION
- Run the Encodec model in Bark via `transformers`, so the `encodec` dependency can be removed.
- Run tests in CI with CPU Pytorch.