### PR TITLE
Support Pytorch 2.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test_aux:	## run aux tests.
 	coverage run -m pytest -x -v --durations=0 tests/aux_tests
 
 test_zoo:	## run zoo tests.
-	coverage run -m pytest -x -v --durations=0 tests/zoo_tests/test_models.py
+	coverage run -m pytest -v --durations=0 tests/zoo_tests/test_models.py
 
 test_zoo_big:	## run tests for models that are too big for CI.
 	coverage run -m pytest -x -v --durations=0 tests/zoo_tests/test_big_models.py

--- a/Makefile
+++ b/Makefile
@@ -67,4 +67,5 @@ install_dev:	## install 🐸 TTS for development.
 	uv run pre-commit install
 
 docs:	## build the docs
-	uv run --group docs $(MAKE) -C docs clean && uv run --group docs $(MAKE) -C docs html
+	uv run --extra cpu --extra codec --group docs $(MAKE) -C docs clean
+	uv run --extra cpu --extra codec --group docs $(MAKE) -C docs html

--- a/README.md
+++ b/README.md
@@ -117,15 +117,29 @@ You can also help us implement more models.
 <!-- start installation -->
 ## Installation
 
-🐸TTS is tested on Ubuntu 24.04 with **python >= 3.10, < 3.15**, but should also
-work on Mac and Windows. Depending on your platform, you might first want to
-separately install Pytorch, `torchaudio`, and `torchcodec` with their
-[official instructions](https://pytorch.org/get-started/locally/).
+> [!NOTE]
+> From `coqui-tts` 0.27.4, PyTorch is not included by default and you need to install it yourself.
+
+🐸TTS is tested on Ubuntu 24.04 with **python >= 3.10, < 3.15** and PyTorch
+2.2+, but should also work on Mac and Windows.
+
+It is strongly recommended to use [uv](https://docs.astral.sh/uv/) to install
+everything into a virtual environment (otherwise leave out `uv` from the
+commands below).
+
+First install PyTorch, `torchaudio`, and (only for PyTorch 2.9+) `torchcodec`
+with their [official instructions](https://pytorch.org/get-started/locally/),
+choosing the CPU/CUDA/ROCm version as necessary. Or let uv automatically select
+the right version for your system:
+
+```bash
+uv pip install torch torchaudio torchcodec --torch-backend=auto
+```
 
 If you are only interested in [synthesizing speech](https://coqui-tts.readthedocs.io/en/latest/inference.html) with the pretrained 🐸TTS models, installing from PyPI is the easiest option.
 
 ```bash
-pip install coqui-tts
+uv pip install coqui-tts
 ```
 
 If you plan to code or train models, clone 🐸TTS and install it locally.
@@ -133,7 +147,7 @@ If you plan to code or train models, clone 🐸TTS and install it locally.
 ```bash
 git clone https://github.com/idiap/coqui-ai-TTS
 cd coqui-ai-TTS
-pip install -e .
+uv pip install -e .
 ```
 
 ### Optional dependencies
@@ -143,7 +157,6 @@ The following extras allow the installation of optional dependencies:
 | Name | Description |
 |------|-------------|
 | `all` | All optional dependencies |
-| `codec` | Installs torchcodec needed with Pytorch>=2.9 |
 | `notebooks` | Dependencies only used in notebooks |
 | `server` | Dependencies to run the TTS server |
 | `bn` | Bangla G2P |
@@ -155,9 +168,23 @@ The following extras allow the installation of optional dependencies:
 You can install extras with one of the following commands:
 
 ```bash
-pip install coqui-tts[server,ja]
-pip install -e .[server,ja]
+uv pip install coqui-tts[server,ja]
+uv pip install -e .[server,ja]
 ```
+
+### Pytorch extras
+
+There are also the following convenience extras to automatically install the
+PyTorch dependencies. Note that the CPU/CUDA selection only works with uv and
+when installing Coqui from source. With other package managers or when installing
+`coqui-tts` from PyPI, the PyTorch dependencies will be installed from PyPI.
+
+| Name | Description |
+|------|-------------|
+| `cpu` | Install `torch`, `torchaudio` (CPU) |
+| `cuda` | Install `torch`, `torchaudio` (CUDA) |
+| `codec` | Install `torchcodec` (CPU), needed with PyTorch>=2.9 |
+| `codec-cuda` | Install `torchcodec` (CUDA), needed with PyTorch>=2.9 |
 
 ### Platforms
 

--- a/TTS/__init__.py
+++ b/TTS/__init__.py
@@ -1,8 +1,13 @@
 import importlib.metadata
 
-from transformers.utils.import_utils import is_torch_greater_or_equal, is_torchcodec_available
+from transformers.utils.import_utils import (
+    is_torch_available,
+    is_torch_greater_or_equal,
+    is_torchaudio_available,
+    is_torchcodec_available,
+)
 
-from TTS.utils.import_utils import TORCHCODEC_IMPORT_ERROR
+from TTS.utils.import_utils import PYTORCH_IMPORT_ERROR, TORCHCODEC_IMPORT_ERROR
 
 __version__ = importlib.metadata.version("coqui-tts")
 
@@ -15,6 +20,8 @@ if "coqpit" in importlib.metadata.packages_distributions().get("coqpit", []):
     )
     raise ImportError(msg)
 
+if not is_torch_available() or not is_torchaudio_available:
+    raise ImportError(PYTORCH_IMPORT_ERROR)
 
 if is_torch_greater_or_equal("2.4"):
     import _codecs

--- a/TTS/tts/utils/text/phonemizers/__init__.py
+++ b/TTS/tts/utils/text/phonemizers/__init__.py
@@ -35,7 +35,6 @@ PHONEMIZERS = {b.name(): b for b in (ESpeak, Gruut) if b is not None}
 ESPEAK_LANGS = list(ESpeak.supported_languages().keys())
 GRUUT_LANGS = [] if Gruut is None else list(Gruut.supported_languages())
 
-
 # Dict setting default phonemizers for each language
 DEF_LANG_TO_PHONEMIZER = {}
 # Add Gruut languages
@@ -46,7 +45,8 @@ if Gruut is not None:
 DEF_LANG_TO_PHONEMIZER.update({lang: ESpeak.name() for lang in ESPEAK_LANGS})
 
 # Force default for some languages
-DEF_LANG_TO_PHONEMIZER["en"] = DEF_LANG_TO_PHONEMIZER["en-us"]
+if "en-us" in DEF_LANG_TO_PHONEMIZER:
+    DEF_LANG_TO_PHONEMIZER["en"] = DEF_LANG_TO_PHONEMIZER["en-us"]
 DEF_LANG_TO_PHONEMIZER["be"] = BEL_Phonemizer.name()
 
 

--- a/TTS/utils/import_utils.py
+++ b/TTS/utils/import_utils.py
@@ -1,3 +1,10 @@
+PYTORCH_IMPORT_ERROR = """
+Coqui TTS requires the PyTorch and Torchaudio libraries but they were not found in your
+environment. Check out the instructions on the installation page:
+https://pytorch.org/get-started/locally/
+and follow the ones that match your environment.
+"""
+
 TORCHCODEC_IMPORT_ERROR = """
 From Pytorch 2.9, the torchcodec library is required for audio IO, but it was not found in your environment. You can install it with Coqui's `codec` extra:
 ```

--- a/TTS/utils/manage.py
+++ b/TTS/utils/manage.py
@@ -46,7 +46,7 @@ LICENSE_URLS = {
     "apache 2.0": "https://choosealicense.com/licenses/apache-2.0/",
     "apache2": "https://choosealicense.com/licenses/apache-2.0/",
     "cc-by-sa 4.0": "https://creativecommons.org/licenses/by-sa/4.0/",
-    "cpml": "https://coqui.ai/cpml.txt",
+    "cpml": "https://tts-hub.github.io/cpml",
 }
 
 
@@ -317,10 +317,10 @@ class ModelManager:
     def ask_tos(model_full_path: Path) -> bool:
         """Ask the user to agree to the terms of service"""
         tos_path = model_full_path / "tos_agreed.txt"
-        print(" > You must confirm the following:")
-        print(' | > "I have purchased a commercial license from Coqui: licensing@coqui.ai"')
-        print(' | > "Otherwise, I agree to the terms of the non-commercial CPML: https://coqui.ai/cpml" - [y/n]')
-        answer = input(" | | > ")
+        print("You must confirm the following:")
+        print('  "I have purchased a commercial license from Coqui: licensing@coqui.ai"')
+        print('  "Otherwise, I agree to the terms of the non-commercial CPML: https://tts-hub.github.io/cpml" - [y/n]')
+        answer = input("   > ")
         if answer.lower() == "y":
             with open(tos_path, "w", encoding="utf-8") as f:
                 f.write("I have read, understood and agreed to the Terms and Conditions.")

--- a/TTS/utils/samplers.py
+++ b/TTS/utils/samplers.py
@@ -14,7 +14,7 @@ class SubsetSampler(Sampler):
     """
 
     def __init__(self, indices):
-        super().__init__(indices)
+        super().__init__()
         self.indices = indices
 
     def __iter__(self):
@@ -48,7 +48,7 @@ class PerfectBatchSampler(Sampler):
         drop_last=False,
         label_key="class_name",
     ):
-        super().__init__(dataset_items)
+        super().__init__()
         assert batch_size % (num_classes_in_batch * num_gpus) == 0, (
             "Batch size must be divisible by number of classes times the number of data parallel devices (if enabled)."
         )
@@ -136,7 +136,7 @@ class SortedSampler(Sampler):
     """
 
     def __init__(self, data, sort_key: Callable = identity):
-        super().__init__(data)
+        super().__init__()
         self.data = data
         self.sort_key = sort_key
         zip_ = [(i, self.sort_key(row)) for i, row in enumerate(self.data)]

--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -1,8 +1,10 @@
+"""The Synthesizer class provides an inference API for TTS and voice conversion models."""
+
 import logging
 import os
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pysbd
@@ -12,18 +14,21 @@ from torch import nn
 from TTS.config import load_config
 from TTS.tts.configs.vits_config import VitsConfig
 from TTS.tts.models import setup_model as setup_tts_model
-from TTS.tts.models.base_tts import BaseTTS
 from TTS.tts.models.vits import Vits
 from TTS.utils.audio import AudioProcessor
 from TTS.utils.audio.numpy_transforms import save_wav
 from TTS.utils.generic_utils import optional_to_str
 from TTS.vc.configs.openvoice_config import OpenVoiceConfig
 from TTS.vc.models import setup_model as setup_vc_model
-from TTS.vc.models.base_vc import BaseVC
 from TTS.vc.models.openvoice import OpenVoice
 from TTS.vocoder.models import setup_model as setup_vocoder_model
-from TTS.vocoder.models.base_vocoder import BaseVocoder
 from TTS.vocoder.utils.generic_utils import interpolate_vocoder_input
+
+if TYPE_CHECKING:
+    from TTS.tts.models.base_tts import BaseTTS
+    from TTS.vc.models.base_vc import BaseVC
+    from TTS.vocoder.models.base_vocoder import BaseVocoder
+
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +37,8 @@ PAD_SILENCE_SAMPLES = 10000
 
 
 class Synthesizer(nn.Module):
+    """Inference API for TTS and voice conversion models."""
+
     def __init__(
         self,
         *,
@@ -49,10 +56,11 @@ class Synthesizer(nn.Module):
         voice_dir: str | os.PathLike[Any] | None = None,
         use_cuda: bool = False,
     ) -> None:
-        """General 🐸 TTS interface for inference. It takes a tts and a vocoder
-        model and synthesize speech from the provided text.
+        """General 🐸 TTS interface for inference.
 
-        The text is divided into a list of sentences using `pysbd` and synthesize
+        It takes a TTS and a vocoder model and synthesizes speech from the provided text.
+
+        The text is divided into a list of sentences using `pysbd` and synthesizes
         speech on each sentence separately.
 
         If you have certain special characters in your text, you need to handle
@@ -70,10 +78,11 @@ class Synthesizer(nn.Module):
             vc_checkpoint (str, optional): path to the voice conversion model file. Defaults to `""`,
             vc_config (str, optional): path to the voice conversion config file. Defaults to `""`,
             use_cuda (bool, optional): enable/disable cuda. Defaults to False.
+
         """
         super().__init__()
-        self.tts_checkpoint = optional_to_str(tts_checkpoint)
-        self.tts_config_path = optional_to_str(tts_config_path)
+        self.tts_checkpoint = Path(optional_to_str(tts_checkpoint))
+        self.tts_config_path = Path(optional_to_str(tts_config_path))
         self.tts_speakers_file = optional_to_str(tts_speakers_file)
         self.tts_languages_file = optional_to_str(tts_languages_file)
         self.vocoder_checkpoint = optional_to_str(vocoder_checkpoint)
@@ -83,7 +92,6 @@ class Synthesizer(nn.Module):
         self.vc_checkpoint = optional_to_str(vc_checkpoint)
         self.vc_config = optional_to_str(vc_config)
         model_dir = optional_to_str(model_dir)
-        self.use_cuda = use_cuda
 
         self.tts_model: BaseTTS | None = None
         self.vocoder_model: BaseVocoder | None = None
@@ -95,25 +103,25 @@ class Synthesizer(nn.Module):
 
         checkpoint_dir = None
         if tts_checkpoint:
-            self._load_tts(self.tts_checkpoint, self.tts_config_path, use_cuda)
-            checkpoint_dir = Path(self.tts_checkpoint)
+            self._load_tts(self.tts_checkpoint, self.tts_config_path, use_cuda=use_cuda)
+            checkpoint_dir = self.tts_checkpoint.parent
 
         if vc_checkpoint and model_dir == "":
-            self._load_vc(self.vc_checkpoint, self.vc_config, use_cuda)
-            checkpoint_dir = Path(self.vc_checkpoint)
+            self._load_vc(self.vc_checkpoint, self.vc_config, use_cuda=use_cuda)
+            checkpoint_dir = Path(self.vc_checkpoint).parent
 
         if vocoder_checkpoint:
-            self._load_vocoder(self.vocoder_checkpoint, self.vocoder_config, use_cuda)
+            self._load_vocoder(self.vocoder_checkpoint, self.vocoder_config, use_cuda=use_cuda)
 
         if model_dir:
             dir_or_file = Path(model_dir)
             checkpoint_dir = dir_or_file if dir_or_file.is_dir() else dir_or_file.parent
             if "fairseq" in model_dir:
-                self._load_fairseq_from_dir(model_dir, use_cuda)
+                self._load_fairseq_from_dir(model_dir, use_cuda=use_cuda)
             elif "openvoice" in model_dir:
-                self._load_openvoice_from_dir(dir_or_file, use_cuda)
+                self._load_openvoice_from_dir(dir_or_file, use_cuda=use_cuda)
             else:
-                self._load_tts_from_dir(dir_or_file, use_cuda)
+                self._load_tts(dir_or_file, use_cuda=use_cuda)
 
         if checkpoint_dir is None:
             msg = "Need to initialize a TTS or VC model via tts_checkpoint/vc_checkpoint/model_dir"
@@ -121,18 +129,19 @@ class Synthesizer(nn.Module):
         self.voice_dir = Path(voice_dir) if voice_dir is not None else checkpoint_dir / "voices"
 
     @staticmethod
-    def _get_segmenter(lang: str):
-        """get the sentence segmenter for the given language.
+    def _get_segmenter(lang: str) -> pysbd.Segmenter:
+        """Get the sentence segmenter for the given language.
 
         Args:
             lang (str): target language code.
 
         Returns:
             [type]: [description]
+
         """
         return pysbd.Segmenter(language=lang, clean=True)
 
-    def _load_vc(self, vc_checkpoint: str, vc_config_path: str, use_cuda: bool) -> None:
+    def _load_vc(self, vc_checkpoint: str, vc_config_path: str, *, use_cuda: bool) -> None:
         """Load the voice conversion model.
 
         1. Load the model config.
@@ -142,10 +151,10 @@ class Synthesizer(nn.Module):
 
         Args:
             vc_checkpoint (str): path to the model checkpoint.
-            tts_config_path (str): path to the model config file.
+            vc_config_path (str): path to the model config file.
             use_cuda (bool): enable/disable CUDA use.
+
         """
-        # pylint: disable=global-statement
         self.vc_config = load_config(vc_config_path)
         self.output_sample_rate = self.vc_config.audio.get(
             "output_sample_rate", self.vc_config.audio.get("sample_rate", None)
@@ -155,10 +164,11 @@ class Synthesizer(nn.Module):
         if use_cuda:
             self.vc_model.cuda()
 
-    def _load_fairseq_from_dir(self, model_dir: str, use_cuda: bool) -> None:
+    def _load_fairseq_from_dir(self, model_dir: str, *, use_cuda: bool) -> None:
         """Load the fairseq model from a directory.
 
-        We assume it is VITS and the model knows how to load itself from the directory and there is a config.json file in the directory.
+        We assume it is VITS and the model knows how to load itself from the
+        directory and there is a config.json file in the directory.
         """
         self.tts_config = VitsConfig()
         self.tts_model = Vits.init_from_config(self.tts_config)
@@ -168,7 +178,7 @@ class Synthesizer(nn.Module):
         if use_cuda:
             self.tts_model.cuda()
 
-    def _load_openvoice_from_dir(self, checkpoint: Path, use_cuda: bool) -> None:
+    def _load_openvoice_from_dir(self, checkpoint: Path, *, use_cuda: bool) -> None:
         """Load the OpenVoice model from a directory.
 
         We assume the model knows how to load itself from the directory and
@@ -182,64 +192,42 @@ class Synthesizer(nn.Module):
         if use_cuda:
             self.vc_model.cuda()
 
-    def _load_tts_from_dir(self, dir_or_file: Path, use_cuda: bool) -> None:
-        """Load the TTS model from a directory.
-
-        We assume the model knows how to load itself from the directory and there is a config.json file in the directory.
-        """
-        checkpoint_dir = dir_or_file if dir_or_file.is_dir() else dir_or_file.parent
-        self.tts_config = load_config(checkpoint_dir / "config.json")
-        if "output_sample_rate" in self.tts_config.audio:
-            self.output_sample_rate = self.tts_config.audio["output_sample_rate"]
-        else:
-            self.output_sample_rate = self.tts_config.audio["sample_rate"]
-        self.tts_model = setup_tts_model(self.tts_config)
-        if dir_or_file.is_dir():
-            self.tts_model.load_checkpoint(self.tts_config, checkpoint_dir=dir_or_file, eval=True)
-        else:
-            self.tts_model.load_checkpoint(self.tts_config, checkpoint_path=dir_or_file, eval=True)
-        if use_cuda:
-            self.tts_model.cuda()
-
-    def _load_tts(self, tts_checkpoint: str, tts_config_path: str, use_cuda: bool) -> None:
+    def _load_tts(self, tts_checkpoint: Path, tts_config_path: Path | None = None, *, use_cuda: bool) -> None:
         """Load the TTS model.
 
-        1. Load the model config.
-        2. Init the model from the config.
-        3. Load the model weights.
-        4. Move the model to the GPU if CUDA is enabled.
-        5. Init the speaker manager in the model.
-
         Args:
-            tts_checkpoint (str): path to the model checkpoint.
-            tts_config_path (str): path to the model config file.
-            use_cuda (bool): enable/disable CUDA use.
+            tts_checkpoint: Path to checkpoint file or directory.
+            tts_config_path: Path to config.json. If None, inferred from checkpoint directory.
+            use_cuda: Enable/disable CUDA use.
+
         """
-        # pylint: disable=global-statement
+        checkpoint_dir = tts_checkpoint if tts_checkpoint.is_dir() else tts_checkpoint.parent
+        if tts_config_path is None:
+            tts_config_path = checkpoint_dir / "config.json"
         self.tts_config = load_config(tts_config_path)
-        self.output_sample_rate = self.tts_config.audio["sample_rate"]
+        self.output_sample_rate = self.tts_config.audio.get("output_sample_rate", self.tts_config.audio["sample_rate"])
         if self.tts_config["use_phonemes"] and self.tts_config["phonemizer"] is None:
-            raise ValueError("Phonemizer is not defined in the TTS config.")
+            msg = "Phonemizer is not defined in the TTS config."
+            raise ValueError(msg)
 
         self.tts_model = setup_tts_model(config=self.tts_config)
 
-        if not self.encoder_checkpoint:
-            self._set_speaker_encoder_paths_from_tts_config()
+        if not self.encoder_checkpoint and self.tts_config.model_args.get("speaker_encoder_config_path"):
+            self.encoder_checkpoint = self.tts_config.model_args.speaker_encoder_model_path
+            self.encoder_config = self.tts_config.model_args.speaker_encoder_config_path
 
-        self.tts_model.load_checkpoint(self.tts_config, tts_checkpoint, eval=True)
+        if tts_checkpoint.is_dir():
+            # We assume the model knows how to load itself from a directory
+            self.tts_model.load_checkpoint(self.tts_config, checkpoint_dir=tts_checkpoint, eval=True)
+        else:
+            self.tts_model.load_checkpoint(self.tts_config, checkpoint_path=tts_checkpoint, eval=True)
         if use_cuda:
             self.tts_model.cuda()
 
         if self.encoder_checkpoint and hasattr(self.tts_model, "speaker_manager"):
             self.tts_model.speaker_manager.init_encoder(self.encoder_checkpoint, self.encoder_config, use_cuda)
 
-    def _set_speaker_encoder_paths_from_tts_config(self):
-        """Set the encoder paths from the tts model config for models with speaker encoders."""
-        if self.tts_config.model_args.get("speaker_encoder_config_path"):
-            self.encoder_checkpoint = self.tts_config.model_args.speaker_encoder_model_path
-            self.encoder_config = self.tts_config.model_args.speaker_encoder_config_path
-
-    def _load_vocoder(self, model_file: str, model_config: str, use_cuda: bool) -> None:
+    def _load_vocoder(self, model_file: str, model_config: str, *, use_cuda: bool) -> None:
         """Load the vocoder model.
 
         1. Load the vocoder config.
@@ -251,6 +239,7 @@ class Synthesizer(nn.Module):
             model_file (str): path to the model checkpoint.
             model_config (str): path to the model config file.
             use_cuda (bool): enable/disable CUDA use.
+
         """
         self.vocoder_config = load_config(model_config)
         self.output_sample_rate = self.vocoder_config.audio["sample_rate"]
@@ -260,7 +249,39 @@ class Synthesizer(nn.Module):
         if use_cuda:
             self.vocoder_model.cuda()
 
-    def split_into_sentences(self, text) -> list[str]:
+    def _run_vocoder(
+        self,
+        mel_postnet_spec: torch.Tensor,
+        vocoder_device: str | torch.device,
+    ) -> torch.Tensor:
+        """Run the vocoder model on mel spectrogram output.
+
+        Args:
+            mel_postnet_spec: Mel spectrogram tensor from TTS model.
+            vocoder_device: Device to run vocoder on.
+
+        Returns:
+            Waveform as numpy array.
+
+        """
+        mel_postnet_spec = mel_postnet_spec.detach().cpu().numpy()
+        # denormalize tts output based on tts audio config
+        mel_postnet_spec = self.tts_model.ap.denormalize(mel_postnet_spec.T).T
+        # renormalize spectrogram based on vocoder config
+        vocoder_input = self.vocoder_ap.normalize(mel_postnet_spec.T)
+        # compute scale factor for possible sample rate mismatch
+        scale_factor = [
+            1,
+            self.vocoder_config["audio"]["sample_rate"] / self.tts_model.ap.sample_rate,
+        ]
+        if scale_factor[1] != 1:
+            logger.info("Interpolating TTS model output.")
+            vocoder_input = interpolate_vocoder_input(scale_factor, vocoder_input)
+        else:
+            vocoder_input = torch.tensor(vocoder_input).unsqueeze(0)
+        return self.vocoder_model.inference(vocoder_input.to(vocoder_device))
+
+    def split_into_sentences(self, text: str) -> list[str]:
         """Split give text into sentences.
 
         Args:
@@ -268,6 +289,7 @@ class Synthesizer(nn.Module):
 
         Returns:
             List[str]: list of sentences.
+
         """
         return self.seg.segment(text)
 
@@ -278,6 +300,7 @@ class Synthesizer(nn.Module):
             wav (List[int]): waveform as a list of values.
             path (str): output path to save the waveform.
             pipe_out (BytesIO, optional): Flag to stdout the generated TTS wav file for shell pipe.
+
         """
         # if tensor convert to numpy
         if isinstance(wav, torch.Tensor):
@@ -293,7 +316,7 @@ class Synthesizer(nn.Module):
         *,
         speaker_id: str | None = None,
         voice_dir: str | os.PathLike[Any] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> list[int]:
         """Run a voice conversion model."""
         start_time = time.time()
@@ -325,14 +348,15 @@ class Synthesizer(nn.Module):
         text: str = "",
         speaker_name: str | None = "",
         language_name: str = "",
-        speaker_wav=None,
+        speaker_wav: str | os.PathLike[Any] | list[str | os.PathLike[Any]] | None = None,
         style_wav=None,
         style_text=None,
         source_wav=None,
         source_speaker_name=None,
+        *,
         split_sentences: bool = True,
         return_dict: bool = False,
-        **kwargs,
+        **kwargs: Any,
     ) -> list[int] | dict[str, Any]:
         """🐸 TTS magic. Run all the models and generate speech.
 
@@ -348,8 +372,10 @@ class Synthesizer(nn.Module):
             split_sentences (bool, optional): split the input text into sentences. Defaults to True.
             return_dict (bool, optional): return additional outputs as a dictionary. Defaults to False.
             **kwargs: additional arguments to pass to the TTS model.
+
         Returns:
             List[int]: [description]
+
         """
         if self.tts_model is None:
             msg = "Text-to-speech model not loaded"
@@ -392,34 +418,16 @@ class Synthesizer(nn.Module):
                     use_griffin_lim=use_gl,
                     **kwargs,
                 )
-                waveform = outputs["wav"]
-                if not use_gl:
-                    mel_postnet_spec = outputs["outputs"]["model_outputs"][0].detach().cpu().numpy()
-                    # denormalize tts output based on tts audio config
-                    mel_postnet_spec = self.tts_model.ap.denormalize(mel_postnet_spec.T).T
-                    # renormalize spectrogram based on vocoder config
-                    vocoder_input = self.vocoder_ap.normalize(mel_postnet_spec.T)
-                    # compute scale factor for possible sample rate mismatch
-                    scale_factor = [
-                        1,
-                        self.vocoder_config["audio"]["sample_rate"] / self.tts_model.ap.sample_rate,
-                    ]
-                    if scale_factor[1] != 1:
-                        logger.info("Interpolating TTS model output.")
-                        vocoder_input = interpolate_vocoder_input(scale_factor, vocoder_input)
-                    else:
-                        vocoder_input = torch.tensor(vocoder_input).unsqueeze(0)  # pylint: disable=not-callable
-                    # run vocoder model
-                    # [1, T, C]
-                    waveform = self.vocoder_model.inference(vocoder_input.to(vocoder_device))
-                if isinstance(waveform, torch.Tensor) and waveform.device != torch.device("cpu") and not use_gl:
-                    waveform = waveform.cpu()
-                if not use_gl:
-                    waveform = waveform.numpy()
+                if use_gl:
+                    waveform = outputs["wav"]
+                else:
+                    waveform = self._run_vocoder(outputs["outputs"]["model_outputs"][0], vocoder_device)
+                if isinstance(waveform, torch.Tensor):
+                    waveform = waveform.cpu().numpy()
                 waveform = waveform.squeeze()
 
                 # trim silence
-                if "do_trim_silence" in self.tts_config.audio and self.tts_config.audio["do_trim_silence"]:
+                if self.tts_config.audio.get("do_trim_silence"):
                     waveform = waveform[: self.tts_model.ap.find_endpoint(waveform)]
 
                 wavs += list(waveform)
@@ -441,31 +449,10 @@ class Synthesizer(nn.Module):
             outputs = self.tts_model.voice_conversion(
                 source_wav, speaker_wav, source_speaker=source_speaker_name, speaker=speaker_name, voice_dir=voice_dir
             )
-            waveform = outputs
-            if not use_gl:
-                mel_postnet_spec = outputs[0].detach().cpu().numpy()
-                # denormalize tts output based on tts audio config
-                mel_postnet_spec = self.tts_model.ap.denormalize(mel_postnet_spec.T).T
-                # renormalize spectrogram based on vocoder config
-                vocoder_input = self.vocoder_ap.normalize(mel_postnet_spec.T)
-                # compute scale factor for possible sample rate mismatch
-                scale_factor = [
-                    1,
-                    self.vocoder_config["audio"]["sample_rate"] / self.tts_model.ap.sample_rate,
-                ]
-                if scale_factor[1] != 1:
-                    logger.info("Interpolating TTS model output.")
-                    vocoder_input = interpolate_vocoder_input(scale_factor, vocoder_input)
-                else:
-                    vocoder_input = torch.tensor(vocoder_input).unsqueeze(0)  # pylint: disable=not-callable
-                # run vocoder model
-                # [1, T, C]
-                waveform = self.vocoder_model.inference(vocoder_input.to(vocoder_device))
-            if isinstance(waveform, torch.Tensor) and waveform.device != torch.device("cpu"):
-                waveform = waveform.cpu()
-            if not use_gl:
-                waveform = waveform.numpy()
-            wavs = waveform.squeeze()
+            wavs = outputs if use_gl else self._run_vocoder(outputs[0], vocoder_device)
+            if isinstance(wavs, torch.Tensor):
+                wavs = wavs.cpu().numpy()
+            wavs = wavs.squeeze()
 
         # compute stats
         process_time = time.time() - start_time

--- a/docs/source/models/tacotron1-2.md
+++ b/docs/source/models/tacotron1-2.md
@@ -22,7 +22,7 @@ If you have a limited VRAM, then you can try using the Guided Attention Loss or 
 ## Important resources & papers
 - Tacotron: [Tacotron: Towards End-to-End Speech Synthesis](https://arxiv.org/abs/1703.10135)
 - Tacotron2: [Natural TTS Synthesis by Conditioning WaveNet on Mel Spectrogram Predictions](https://arxiv.org/abs/1712.05884)
-- Double Decoder Consistency: https://coqui.ai/blog/tts/solving-attention-problems-of-tts-models-with-double-decoder-consistency
+- Double Decoder Consistency: [Solving Attention Problems of TTS models with Double Decoder Consistency](https://web.archive.org/web/20250725051603/https://coqui.ai/blog/tts/solving-attention-problems-of-tts-models-with-double-decoder-consistency/)
 - Guided Attention Loss: https://arxiv.org/abs/1710.08969
 - Forward & Backward Decoder: https://arxiv.org/abs/1907.09006
 - Forward Attention: https://arxiv.org/abs/1807.06736

--- a/docs/source/models/xtts.md
+++ b/docs/source/models/xtts.md
@@ -40,7 +40,7 @@ XTTS-v2 supports 17 languages:
 - Turkish (tr)
 
 ## License
-This model is licensed under [Coqui Public Model License](https://coqui.ai/cpml).
+This model is licensed under [Coqui Public Model License](https://tts-hub.github.io/cpml).
 
 ## Contact
 Come and join in our 🐸Community. We're active on [Discord](https://discord.gg/fBC58unbKE) and [GitHub](https://github.com/idiap/coqui-ai-TTS/discussions).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,7 @@ lint.extend-select = [
 ]
 
 lint.ignore = [
+    "COM812", # not recommended with formatter
     "E722", # bare except (TODO: fix these)
     "E731", # don't use lambdas
     "E741", # ambiguous variable name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,9 +138,9 @@ languages = [
     "gruut[de,es,fr]>=2.4.0",
     "uroman>=1.3.1.1",
 ]
-# Installs all extras (except dev and docs)
+# Installs all extras (except torch, dev and docs)
 all = [
-    "coqui-tts[codec,notebooks,server,bn,ja,ko,zh]",
+    "coqui-tts[notebooks,server,languages]",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,9 +144,6 @@ all = [
 ]
 
 [tool.uv]
-constraint-dependencies = [
-    "torch<2.10",
-]
 required-environments = [
     "sys_platform == 'linux' and platform_machine == 'x86_64'"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coqui-tts"
-version = "0.27.3"
+version = "0.28.0.dev0"
 description = "Deep learning for Text to Speech."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"


### PR DESCRIPTION
- Add instructions for installing Pytorch since Coqui does not install it by default anymore. Fixes #546
- Remove deprecated argument from custom samplers that was removed in Pytorch 2.10
- Don't crash when Espeak is not installed. Fixes #547
- Update links to the Coqui Public Model License text to https://tts-hub.github.io/cpml/ because the coqui.ai website does not exist anymore.
- Deduplicate code in Synthesizer class
