### PR TITLE
Improve import/startup time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,17 @@ RUN if echo "$BASE" | grep -q "cuda"; then \
     else \
       UV_TORCH_BACKEND=cpu; \
     fi && \
-    uv pip install -r pyproject.toml --extra all --torch-backend=${UV_TORCH_BACKEND}
+    uv pip install torch torchaudio torchcodec --torch-backend=${UV_TORCH_BACKEND} && \
+    uv pip install -r pyproject.toml --extra all
 
 # Copy the rest of the application
 COPY . /app
 
 # Install the project
 RUN uv pip install -e .
+
+# Verify installation works
+RUN uv run --active python -c "from TTS.api import TTS"
 
 ENTRYPOINT ["tts"]
 CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,12 @@ data_tests: ## run data tests.
 test_text: ## run text tests.
 	coverage run -m pytest -x -v --durations=0 tests/text_tests
 
+test_fast: ## run fast tests (for local testing)
+	uv run --all-extras --no-extra cuda --no-extra codec-cuda \
+		coverage run -m pytest -v --durations=0 \
+		tests/aux_tests tests/data_tests \
+		tests/text_tests tests/inference_tests
+
 test_notebook: ## run Jupyter notebook tests
 	NB_OUTPUT_DIR=/tmp/coqui uv run --with nbval \
 		--extra cpu --extra codec --extra languages --extra notebooks \

--- a/TTS/__init__.py
+++ b/TTS/__init__.py
@@ -1,13 +1,13 @@
 import importlib.metadata
 
-from transformers.utils.import_utils import (
+from TTS.utils.import_utils import (
+    PYTORCH_IMPORT_ERROR,
+    TORCHCODEC_IMPORT_ERROR,
     is_torch_available,
     is_torch_greater_or_equal,
     is_torchaudio_available,
     is_torchcodec_available,
 )
-
-from TTS.utils.import_utils import PYTORCH_IMPORT_ERROR, TORCHCODEC_IMPORT_ERROR
 
 __version__ = importlib.metadata.version("coqui-tts")
 
@@ -20,7 +20,7 @@ if "coqpit" in importlib.metadata.packages_distributions().get("coqpit", []):
     )
     raise ImportError(msg)
 
-if not is_torch_available() or not is_torchaudio_available:
+if not is_torch_available() or not is_torchaudio_available():
     raise ImportError(PYTORCH_IMPORT_ERROR)
 
 if is_torch_greater_or_equal("2.9"):

--- a/TTS/api.py
+++ b/TTS/api.py
@@ -32,7 +32,6 @@ class TTS(nn.Module):
         encoder_path: str | None = None,
         encoder_config_path: str | None = None,
         speakers_file_path: str | None = None,
-        language_ids_file_path: str | None = None,
         progress_bar: bool = True,
         gpu: bool = False,
     ) -> None:
@@ -72,7 +71,6 @@ class TTS(nn.Module):
             encoder_path: Path to speaker encoder checkpoint. Default to None.
             encoder_config_path: Path to speaker encoder config file. Defaults to None.
             speakers_file_path: JSON file for multi-speaker model. Defaults to None.
-            language_ids_file_path: JSON file for multilingual model. Defaults to None
             progress_bar (bool, optional): Whether to print a progress bar while downloading a model. Defaults to True.
             gpu (bool, optional): Enable/disable GPU. Defaults to False. DEPRECATED, use TTS(...).to("cuda")
         """
@@ -89,7 +87,6 @@ class TTS(nn.Module):
         self.encoder_path = encoder_path
         self.encoder_config_path = encoder_config_path
         self.speakers_file_path = speakers_file_path
-        self.language_ids_file_path = language_ids_file_path
 
         if gpu:
             warnings.warn("`gpu` will be deprecated. Please use `tts.to(device)` instead.")
@@ -226,7 +223,6 @@ class TTS(nn.Module):
             tts_checkpoint=model_path,
             tts_config_path=config_path,
             tts_speakers_file=None,
-            tts_languages_file=None,
             vocoder_checkpoint=vocoder_path,
             vocoder_config=vocoder_config_path,
             encoder_checkpoint=self.encoder_path,
@@ -250,7 +246,6 @@ class TTS(nn.Module):
             tts_checkpoint=model_path,
             tts_config_path=config_path,
             tts_speakers_file=self.speakers_file_path,
-            tts_languages_file=self.language_ids_file_path,
             vocoder_checkpoint=self.vocoder_path,
             vocoder_config=self.vocoder_config_path,
             encoder_checkpoint=self.encoder_path,

--- a/TTS/bin/find_unique_phonemes.py
+++ b/TTS/bin/find_unique_phonemes.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 
 from TTS.config import load_config
 from TTS.tts.datasets import load_tts_samples
-from TTS.tts.utils.text.phonemizers import Gruut
+from TTS.tts.utils.text.phonemizers.gruut_wrapper import Gruut
 from TTS.utils.generic_utils import ConsoleFormatter, setup_logger
 
 phonemizer: Gruut

--- a/TTS/bin/synthesize.py
+++ b/TTS/bin/synthesize.py
@@ -216,7 +216,6 @@ def parse_args(arg_list: list[str] | None) -> argparse.Namespace:
 
     # args for multi-speaker synthesis
     parser.add_argument("--speakers_file_path", type=str, help="JSON file for multi-speaker model.", default=None)
-    parser.add_argument("--language_ids_file_path", type=str, help="JSON file for multi-lingual model.", default=None)
     parser.add_argument(
         "--speaker_idx",
         type=str,
@@ -336,7 +335,6 @@ def main(arg_list: list[str] | None = None) -> None:
         tts_path = None
         tts_config_path = None
         speakers_file_path = None
-        language_ids_file_path = None
         vocoder_path = None
         vocoder_config_path = None
         encoder_path = None
@@ -381,7 +379,6 @@ def main(arg_list: list[str] | None = None) -> None:
             encoder_path=args.encoder_path,
             encoder_config_path=args.encoder_config_path,
             speakers_file_path=args.speakers_file_path,
-            language_ids_file_path=args.language_ids_file_path,
             progress_bar=args.progress_bar,
         ).to(device)
 

--- a/TTS/encoder/utils/generic_utils.py
+++ b/TTS/encoder/utils/generic_utils.py
@@ -4,7 +4,7 @@ import os
 import random
 
 import numpy as np
-from scipy import signal
+import scipy
 
 from TTS.encoder.models.base_encoder import BaseEncoder
 from TTS.encoder.models.lstm import LSTMSpeakerEncoder
@@ -111,7 +111,7 @@ class AugmentWAV:
         rir_file = random.choice(self.rir_files)
         rir = self.ap.load_wav(rir_file, sr=self.ap.sample_rate)
         rir = rir / np.sqrt(np.sum(rir**2))
-        return signal.convolve(audio, rir, mode=self.rir_config["conv_mode"])[:audio_len]
+        return scipy.signal.convolve(audio, rir, mode=self.rir_config["conv_mode"])[:audio_len]
 
     def apply_one(self, audio):
         noise_type = random.choice(self.global_noise_list)

--- a/TTS/server/server.py
+++ b/TTS/server/server.py
@@ -104,7 +104,6 @@ api = TTS(
     vocoder_path=args.vocoder_path,
     vocoder_config_path=args.vocoder_config_path,
     speakers_file_path=args.speakers_file_path,
-    # language_ids_file_path=args.language_ids_file_path,
 ).to(device)
 
 # TODO: set this from SpeakerManager

--- a/TTS/tts/configs/shared_configs.py
+++ b/TTS/tts/configs/shared_configs.py
@@ -137,19 +137,19 @@ class CharactersConfig(Coqpit):
             Sort the characters in alphabetical order. Defaults to True.
     """
 
-    characters_class: str = None
+    characters_class: str | None = None
 
     # using BaseVocabulary
     vocab_dict: list[str] | None = None
 
     # using on BaseCharacters
-    pad: str = "<PAD>"
-    eos: str = None
-    bos: str = None
-    blank: str = None
-    characters: str = None
-    punctuations: str = None
-    phonemes: str = None
+    pad: str | None = "<PAD>"
+    eos: str | None = None
+    bos: str | None = None
+    blank: str | None = None
+    characters: str | None = None
+    punctuations: str | None = None
+    phonemes: str | None = None
     is_unique: bool = True  # for backwards compatibility of models trained with char sets with duplicates
     is_sorted: bool = True
 
@@ -307,15 +307,15 @@ class BaseTTSConfig(BaseTrainingConfig):
     _supports_cloning: bool = False
     # phoneme settings
     use_phonemes: bool = False
-    phonemizer: str = None
-    phoneme_language: str = None
+    phonemizer: str | None = None
+    phoneme_language: str | None = None
     compute_input_seq_cache: bool = False
-    text_cleaner: str = None
+    text_cleaner: str | None = None
     enable_eos_bos_chars: bool = False
     test_sentences_file: str = ""
     phoneme_cache_path: str = None
     # vocabulary parameters
-    characters: CharactersConfig = None
+    characters: CharactersConfig | None = None
     add_blank: bool = False
     # training params
     batch_group_size: int = 0

--- a/TTS/tts/datasets/dataset.py
+++ b/TTS/tts/datasets/dataset.py
@@ -11,11 +11,11 @@ import numpy.typing as npt
 import torch
 import tqdm
 from torch.utils.data import Dataset
-from transformers.utils.import_utils import is_torch_greater_or_equal
 
 from TTS.tts.utils.data import prepare_data, prepare_stop_target, prepare_tensor
 from TTS.utils.audio import AudioProcessor
 from TTS.utils.audio.numpy_transforms import compute_energy as calculate_energy
+from TTS.utils.import_utils import is_torch_greater_or_equal
 
 logger = logging.getLogger(__name__)
 

--- a/TTS/tts/layers/overflow/plotting_utils.py
+++ b/TTS/tts/layers/overflow/plotting_utils.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-import matplotlib.pyplot as plt
 import numpy as np
 import torch
 
@@ -63,6 +62,8 @@ def plot_transition_probabilities_to_numpy(states, transition_probabilities, out
         states (torch.IntTensor): the states
         transition_probabilities (torch.FloatTensor): the transition probabilities
     """
+    import matplotlib.pyplot as plt
+
     states = validate_numpy_array(states)
     transition_probabilities = validate_numpy_array(transition_probabilities)
 

--- a/TTS/tts/layers/tacotron/attentions.py
+++ b/TTS/tts/layers/tacotron/attentions.py
@@ -1,5 +1,5 @@
+import scipy
 import torch
-from scipy.stats import betabinom
 from torch import nn
 from torch.nn import functional as F
 
@@ -385,7 +385,7 @@ class MonotonicDynamicConvolutionAttention(nn.Module):
         self.dynamic_filter_layer = nn.Linear(dynamic_filter_dim, attention_dim)
         self.v = nn.Linear(attention_dim, 1, bias=False)
 
-        prior = betabinom.pmf(range(prior_filter_len), prior_filter_len - 1, alpha, beta)
+        prior = scipy.stats.betabinom.pmf(range(prior_filter_len), prior_filter_len - 1, alpha, beta)
         self.register_buffer("prior", torch.FloatTensor(prior).flip(0))
 
     # pylint: disable=unused-argument

--- a/TTS/tts/layers/xtts/xtts_manager.py
+++ b/TTS/tts/layers/xtts/xtts_manager.py
@@ -1,22 +1,25 @@
+import os
+from typing import Any
+
 import torch
 
 from TTS.utils.generic_utils import is_pytorch_at_least_2_4
 
 
 class SpeakerManager:
-    def __init__(self, speaker_file_path=None):
+    def __init__(self, speaker_file_path: str | os.PathLike[Any]) -> None:
         self.speakers = torch.load(speaker_file_path, weights_only=is_pytorch_at_least_2_4())
 
     @property
-    def name_to_id(self):
+    def name_to_id(self) -> dict[str, dict[str, torch.Tensor]]:
         return self.speakers
 
     @property
-    def num_speakers(self):
+    def num_speakers(self) -> int:
         return len(self.name_to_id)
 
     @property
-    def speaker_names(self):
+    def speaker_names(self) -> list[str]:
         return list(self.name_to_id.keys())
 
 

--- a/TTS/tts/models/align_tts.py
+++ b/TTS/tts/models/align_tts.py
@@ -13,7 +13,6 @@ from TTS.tts.models.base_tts import BaseTTS
 from TTS.tts.utils.helpers import expand_encoder_outputs, generate_attention, sequence_mask
 from TTS.tts.utils.speakers import SpeakerManager
 from TTS.tts.utils.text.tokenizer import TTSTokenizer
-from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
 
 
 class AlignTTS(BaseTTS):
@@ -282,6 +281,8 @@ class AlignTTS(BaseTTS):
         return outputs, loss_dict
 
     def _create_logs(self, batch, outputs):
+        from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
+
         model_outputs = outputs["model_outputs"]
         alignments = outputs["alignments"]
         mel_input = batch["mel_input"]

--- a/TTS/tts/models/base_tts.py
+++ b/TTS/tts/models/base_tts.py
@@ -22,7 +22,6 @@ from TTS.tts.utils.data import get_length_balancer_weights
 from TTS.tts.utils.languages import LanguageManager, get_language_balancer_weights
 from TTS.tts.utils.speakers import SpeakerManager, get_speaker_balancer_weights
 from TTS.tts.utils.synthesis import inv_spectrogram
-from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
 from TTS.utils.generic_utils import warn_synthesize_config_deprecated, warn_synthesize_speaker_id_deprecated
 from TTS.utils.voices import CloningMixin
 
@@ -411,6 +410,8 @@ class BaseTTS(CloningMixin, BaseTrainerModel):
         Returns:
             Dictionary with test figures and audios to be projected to Tensorboard.
         """
+        from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
+
         logger.info("Synthesizing test sentences.")
         test_audios = {}
         test_figures = {}

--- a/TTS/tts/models/delightful_tts.py
+++ b/TTS/tts/models/delightful_tts.py
@@ -32,7 +32,6 @@ from TTS.tts.models.vits import load_audio
 from TTS.tts.utils.helpers import average_over_durations, compute_attn_prior, rand_segments, segment, sequence_mask
 from TTS.tts.utils.speakers import SpeakerManager
 from TTS.tts.utils.text.tokenizer import TTSTokenizer
-from TTS.tts.utils.visual import plot_alignment, plot_avg_pitch, plot_pitch, plot_spectrogram
 from TTS.utils.audio.numpy_transforms import build_mel_basis, compute_f0
 from TTS.utils.audio.numpy_transforms import db_to_amp as db_to_amp_numpy
 from TTS.utils.audio.numpy_transforms import mel_to_wav as mel_to_wav_numpy
@@ -674,6 +673,8 @@ class DelightfulTTS(BaseTTSE2E):
         raise ValueError(" [!] Unexpected `optimizer_idx`.")
 
     def _create_logs(self, batch, outputs):
+        from TTS.tts.utils.visual import plot_alignment, plot_avg_pitch, plot_spectrogram
+
         figures, audios = {}, {}
 
         # encoder outputs
@@ -733,6 +734,8 @@ class DelightfulTTS(BaseTTSE2E):
         return figures, audios
 
     def plot_outputs(self, text, wav, alignment, outputs):
+        from TTS.tts.utils.visual import plot_alignment, plot_avg_pitch, plot_pitch, plot_spectrogram
+
         figures = {}
         pitch_avg_pred = outputs["pitch"].cpu()
         energy_avg_pred = outputs["energy"].cpu()
@@ -850,6 +853,8 @@ class DelightfulTTS(BaseTTSE2E):
         Returns:
             Dictionary with test figures and audios to be projected to Tensorboard.
         """
+        from TTS.tts.utils.visual import plot_alignment
+
         logger.info("Synthesizing test sentences.")
         test_audios = {}
         test_figures = {}

--- a/TTS/tts/models/forward_tts.py
+++ b/TTS/tts/models/forward_tts.py
@@ -15,7 +15,6 @@ from TTS.tts.models.base_tts import BaseTTS
 from TTS.tts.utils.helpers import average_over_durations, expand_encoder_outputs, generate_attention, sequence_mask
 from TTS.tts.utils.speakers import SpeakerManager
 from TTS.tts.utils.text.tokenizer import TTSTokenizer
-from TTS.tts.utils.visual import plot_alignment, plot_avg_energy, plot_avg_pitch, plot_spectrogram
 
 logger = logging.getLogger(__name__)
 
@@ -558,6 +557,8 @@ class ForwardTTS(BaseTTS):
 
     def _create_logs(self, batch, outputs):
         """Create common logger outputs."""
+        from TTS.tts.utils.visual import plot_alignment, plot_avg_energy, plot_avg_pitch, plot_spectrogram
+
         model_outputs = outputs["model_outputs"]
         alignments = outputs["alignments"]
         mel_input = batch["mel_input"]

--- a/TTS/tts/models/glow_tts.py
+++ b/TTS/tts/models/glow_tts.py
@@ -15,7 +15,6 @@ from TTS.tts.models.base_tts import BaseTTS
 from TTS.tts.utils.helpers import generate_path, sequence_mask
 from TTS.tts.utils.speakers import SpeakerManager
 from TTS.tts.utils.text.tokenizer import TTSTokenizer
-from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
 
 logger = logging.getLogger(__name__)
 
@@ -395,6 +394,8 @@ class GlowTTS(BaseTTS):
         return outputs, loss_dict
 
     def _create_logs(self, batch, outputs):
+        from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
+
         alignments = outputs["alignments"]
         text_input = batch["text_input"][:1] if batch["text_input"] is not None else None
         text_lengths = batch["text_lengths"]

--- a/TTS/tts/models/neuralhmm_tts.py
+++ b/TTS/tts/models/neuralhmm_tts.py
@@ -19,7 +19,6 @@ from TTS.tts.layers.overflow.plotting_utils import (
 from TTS.tts.models.base_tts import BaseTTS
 from TTS.tts.utils.speakers import SpeakerManager
 from TTS.tts.utils.text.tokenizer import TTSTokenizer
-from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
 from TTS.utils.generic_utils import format_aux_input, is_pytorch_at_least_2_4
 
 logger = logging.getLogger(__name__)
@@ -301,6 +300,8 @@ class NeuralhmmTTS(BaseTTS):
 
     @torch.inference_mode()
     def _create_logs(self, batch, outputs):
+        from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
+
         alignments, transition_vectors = outputs["alignments"], outputs["transition_vectors"]
         means = torch.stack(outputs["means"], dim=1)
 

--- a/TTS/tts/models/overflow.py
+++ b/TTS/tts/models/overflow.py
@@ -20,7 +20,6 @@ from TTS.tts.layers.overflow.plotting_utils import (
 from TTS.tts.models.base_tts import BaseTTS
 from TTS.tts.utils.speakers import SpeakerManager
 from TTS.tts.utils.text.tokenizer import TTSTokenizer
-from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
 from TTS.utils.generic_utils import format_aux_input, is_pytorch_at_least_2_4
 
 logger = logging.getLogger(__name__)
@@ -329,6 +328,8 @@ class Overflow(BaseTTS):
         trainer.model.update_mean_std(statistics)
 
     def _create_logs(self, batch, outputs):
+        from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
+
         alignments, transition_vectors = outputs["alignments"], outputs["transition_vectors"]
         means = torch.stack(outputs["means"], dim=1)
 

--- a/TTS/tts/models/tacotron.py
+++ b/TTS/tts/models/tacotron.py
@@ -12,7 +12,6 @@ from TTS.tts.models.base_tacotron import BaseTacotron
 from TTS.tts.utils.measures import alignment_diagonal_score
 from TTS.tts.utils.speakers import SpeakerManager
 from TTS.tts.utils.text.tokenizer import TTSTokenizer
-from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
 from TTS.utils.capacitron_optimizer import CapacitronOptimizer
 
 
@@ -344,6 +343,8 @@ class Tacotron(BaseTacotron):
             torch.nn.utils.clip_grad_norm_(model_params_to_clip, self.capacitron_vae.capacitron_grad_clip)
 
     def _create_logs(self, batch, outputs):
+        from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
+
         postnet_outputs = outputs["model_outputs"]
         decoder_outputs = outputs["decoder_outputs"]
         alignments = outputs["alignments"]

--- a/TTS/tts/models/tacotron2.py
+++ b/TTS/tts/models/tacotron2.py
@@ -13,7 +13,6 @@ from TTS.tts.models.base_tacotron import BaseTacotron
 from TTS.tts.utils.measures import alignment_diagonal_score
 from TTS.tts.utils.speakers import SpeakerManager
 from TTS.tts.utils.text.tokenizer import TTSTokenizer
-from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
 from TTS.utils.capacitron_optimizer import CapacitronOptimizer
 
 
@@ -379,6 +378,8 @@ class Tacotron2(BaseTacotron):
 
     def _create_logs(self, batch, outputs):
         """Create dashboard log information."""
+        from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
+
         postnet_outputs = outputs["model_outputs"]
         alignments = outputs["alignments"]
         alignments_backward = outputs["alignments_backward"]

--- a/TTS/tts/models/vits.py
+++ b/TTS/tts/models/vits.py
@@ -34,7 +34,6 @@ from TTS.tts.utils.languages import LanguageManager
 from TTS.tts.utils.speakers import SpeakerManager
 from TTS.tts.utils.text.characters import BaseCharacters, BaseVocabulary, _characters, _pad, _phonemes, _punctuations
 from TTS.tts.utils.text.tokenizer import TTSTokenizer
-from TTS.tts.utils.visual import plot_alignment
 from TTS.utils.audio.torch_transforms import spec_to_mel, wav_to_mel, wav_to_spec
 from TTS.utils.samplers import BucketBatchSampler
 from TTS.vocoder.models.hifigan_generator import HifiganGenerator
@@ -889,6 +888,8 @@ class Vits(BaseTTS):
         raise ValueError(" [!] Unexpected `optimizer_idx`.")
 
     def _create_logs(self, batch, outputs: list[dict[str, Any]]):
+        from TTS.tts.utils.visual import plot_alignment
+
         y_hat = outputs[1]["model_outputs"]
         y = outputs[1]["waveform_seg"]
         figures = plot_results(y_hat, y, self.ap)
@@ -908,6 +909,8 @@ class Vits(BaseTTS):
         Returns:
             Dictionary with test figures and audios to be projected to Tensorboard.
         """
+        from TTS.tts.utils.visual import plot_alignment
+
         logger.info("Synthesizing test sentences.")
         test_audios = {}
         test_figures = {}

--- a/TTS/tts/models/vits.py
+++ b/TTS/tts/models/vits.py
@@ -20,7 +20,7 @@ from trainer.io import load_fsspec
 from trainer.torch import DistributedSampler, DistributedSamplerWrapper
 from trainer.trainer_utils import get_optimizer, get_scheduler
 
-from TTS.tts.configs.shared_configs import CharactersConfig
+from TTS.tts.configs.shared_configs import BaseTTSConfig, CharactersConfig
 from TTS.tts.configs.vits_config import VitsArgs, VitsConfig
 from TTS.tts.datasets.dataset import TTSDataset, _parse_sample, get_attribute_balancer_weights
 from TTS.tts.layers.glow_tts.duration_predictor import DurationPredictor
@@ -1209,7 +1209,7 @@ class Vits(BaseTTS):
         self.config.audio.sample_rate = config_org["data"]["sampling_rate"]
         is_uroman = config_org["data"]["training_files"].endswith("uroman")
         # set tokenizer
-        vocab = FairseqVocab(vocab_file)
+        vocab = FairseqVocab.init_from_vocab_file(vocab_file)
         self.text_encoder.emb = nn.Embedding(vocab.num_chars, config.model_args.hidden_channels)
         self.tokenizer = TTSTokenizer(
             use_phonemes=False,
@@ -1404,22 +1404,32 @@ class VitsCharacters(BaseCharacters):
     ) -> None:
         if ipa_characters is not None:
             graphemes += ipa_characters
-        super().__init__(graphemes, punctuations, pad, None, None, "<BLNK>", is_unique=False, is_sorted=True)
+        super().__init__(
+            characters=graphemes,
+            punctuations=punctuations,
+            pad=pad,
+            eos=None,
+            bos=None,
+            blank="<BLNK>",
+            is_unique=False,
+            is_sorted=True,
+        )
 
     def _create_vocab(self):
-        self._vocab = [self._pad] + list(self._punctuations) + list(self._characters) + [self._blank]
+        self._vocab = [self.pad, *self.punctuations, *self.characters, self.blank]
         self._char_to_id = {char: idx for idx, char in enumerate(self.vocab)}
         self._id_to_char = dict(enumerate(self.vocab))
 
     @staticmethod
-    def init_from_config(config: Coqpit):
+    def init_from_config(config: BaseTTSConfig):
         if config.characters is not None:
-            _pad = config.characters["pad"]
-            _punctuations = config.characters["punctuations"]
-            _letters = config.characters["characters"]
-            _letters_ipa = config.characters["phonemes"]
             return (
-                VitsCharacters(graphemes=_letters, ipa_characters=_letters_ipa, punctuations=_punctuations, pad=_pad),
+                VitsCharacters(
+                    graphemes=config.characters["characters"],
+                    ipa_characters=config.characters["phonemes"],
+                    punctuations=config.characters["punctuations"],
+                    pad=config.characters["pad"],
+                ),
                 config,
             )
         characters = VitsCharacters()
@@ -1428,31 +1438,26 @@ class VitsCharacters(BaseCharacters):
 
     def to_config(self) -> "CharactersConfig":
         return CharactersConfig(
-            characters=self._characters,
-            punctuations=self._punctuations,
-            pad=self._pad,
+            characters=self.characters,
+            punctuations=self.punctuations,
+            pad=self.pad,
             eos=None,
             bos=None,
-            blank=self._blank,
+            blank=self.blank,
             is_unique=False,
             is_sorted=True,
         )
 
 
 class FairseqVocab(BaseVocabulary):
-    def __init__(self, vocab: str | os.PathLike[Any]) -> None:
-        self.vocab = vocab
-
-    @property
-    def vocab(self) -> list[str]:
-        """Return the vocabulary dictionary."""
-        return self._vocab
-
-    @vocab.setter
-    def vocab(self, vocab_file: str | os.PathLike[Any]) -> None:
-        with open(vocab_file, encoding="utf-8") as f:
-            self._vocab = [line.replace("\n", "") for line in f]
-        self.blank = self._vocab[0]
-        self.pad = " "
-        self._char_to_id = {s: i for i, s in enumerate(self._vocab)}  # pylint: disable=unnecessary-comprehension
-        self._id_to_char = dict(enumerate(self._vocab))
+    @staticmethod
+    def init_from_vocab_file(vocab_file: Path) -> "FairseqVocab":
+        """Create vocabulary from a Fairseq vocab.txt file."""
+        vocab = FairseqVocab(vocab=None)
+        with vocab_file.open(encoding="utf-8") as f:
+            vocab._vocab = [line.replace("\n", "") for line in f]
+        vocab.blank = vocab._vocab[0]
+        vocab.pad = " "
+        vocab._char_to_id = {s: i for i, s in enumerate(vocab._vocab)}
+        vocab._id_to_char = dict(enumerate(vocab._vocab))
+        return vocab

--- a/TTS/tts/models/xtts.py
+++ b/TTS/tts/models/xtts.py
@@ -142,6 +142,7 @@ class Xtts(BaseTTS):
     """
 
     config: XttsConfig
+    tokenizer: VoiceBpeTokenizer
 
     def __init__(self, config: Coqpit):
         super().__init__(config, ap=None, tokenizer=None)

--- a/TTS/tts/utils/helpers.py
+++ b/TTS/tts/utils/helpers.py
@@ -1,6 +1,6 @@
 import numpy as np
+import scipy
 import torch
-from scipy.stats import betabinom
 from torch.nn import functional as F
 
 
@@ -220,7 +220,7 @@ def beta_binomial_prior_distribution(phoneme_count, mel_count, scaling_factor=1.
     mel_text_probs = []
     for i in range(1, M + 1):
         a, b = scaling_factor * i, scaling_factor * (M + 1 - i)
-        rv = betabinom(P, a, b)
+        rv = scipy.stats.betabinom(P, a, b)
         mel_i_prob = rv.pmf(x)
         mel_text_probs.append(mel_i_prob)
     return np.array(mel_text_probs)

--- a/TTS/tts/utils/text/bangla/phonemizer.py
+++ b/TTS/tts/utils/text/bangla/phonemizer.py
@@ -1,11 +1,8 @@
 import re
 
-try:
-    import bangla
-    from bnnumerizer import numerize
-    from bnunicodenormalizer import Normalizer
-except ImportError as e:
-    raise ImportError("Bangla requires: bangla, bnnumerizer, bnunicodenormalizer") from e
+import bangla
+from bnnumerizer import numerize
+from bnunicodenormalizer import Normalizer
 
 # initialize
 bnorm = Normalizer()

--- a/TTS/tts/utils/text/characters.py
+++ b/TTS/tts/utils/text/characters.py
@@ -47,7 +47,12 @@ class BaseVocabulary:
     """
 
     def __init__(
-        self, vocab: list[str] | None, pad: str = None, blank: str = None, bos: str = None, eos: str = None
+        self,
+        vocab: list[str] | None,
+        pad: str | None = None,
+        blank: str | None = None,
+        bos: str | None = None,
+        eos: str | None = None,
     ) -> None:
         self.vocab = vocab
         self.pad = pad
@@ -57,26 +62,34 @@ class BaseVocabulary:
 
     @property
     def pad_id(self) -> int:
-        """Return the index of the padding character. If the padding character is not specified, return the length
-        of the vocabulary."""
+        """Return the index of the padding character.
+
+        If the padding character is not specified, return the length of the vocabulary.
+        """
         return self.char_to_id(self.pad) if self.pad else len(self.vocab)
 
     @property
     def blank_id(self) -> int:
-        """Return the index of the blank character. If the blank character is not specified, return the length of
-        the vocabulary."""
+        """Return the index of the blank character.
+
+        If the blank character is not specified, return the length of the vocabulary.
+        """
         return self.char_to_id(self.blank) if self.blank else len(self.vocab)
 
     @property
     def bos_id(self) -> int:
-        """Return the index of the bos character. If the bos character is not specified, return the length of the
-        vocabulary."""
+        """Return the index of the bos character.
+
+        If the bos character is not specified, return the length of the vocabulary.
+        """
         return self.char_to_id(self.bos) if self.bos else len(self.vocab)
 
     @property
     def eos_id(self) -> int:
-        """Return the index of the eos character. If the eos character is not specified, return the length of the
-        vocabulary."""
+        """Return the index of the eos character.
+
+        If the eos character is not specified, return the length of the vocabulary.
+        """
         return self.char_to_id(self.eos) if self.eos else len(self.vocab)
 
     @property
@@ -94,9 +107,9 @@ class BaseVocabulary:
             self._id_to_char = dict(enumerate(self._vocab))
 
     @staticmethod
-    def init_from_config(config: BaseTTSConfig, **kwargs) -> tuple["BaseVocabulary", BaseTTSConfig]:
+    def init_from_config(config: BaseTTSConfig) -> tuple["BaseVocabulary", BaseTTSConfig]:
         """Initialize from the given config."""
-        if config.characters is not None and "vocab_dict" in config.characters and config.characters.vocab_dict:
+        if config.characters is not None and config.characters.get("vocab_dict"):
             return (
                 BaseVocabulary(
                     config.characters.vocab_dict,
@@ -107,7 +120,8 @@ class BaseVocabulary:
                 ),
                 config,
             )
-        return BaseVocabulary(**kwargs), config
+        msg = "Missing `characters` or `characters.vocab_dict` in config."
+        raise ValueError(msg)
 
     def to_config(self) -> "CharactersConfig":
         return CharactersConfig(
@@ -126,7 +140,7 @@ class BaseVocabulary:
         return len(self._vocab)
 
     def char_to_id(self, char: str) -> int:
-        """Map a character to an token ID."""
+        """Map a character to a token ID."""
         try:
             return self._char_to_id[char]
         except KeyError as e:
@@ -134,11 +148,11 @@ class BaseVocabulary:
             raise KeyError(msg) from e
 
     def id_to_char(self, idx: int) -> str:
-        """Map an token ID to a character."""
+        """Map a token ID to a character."""
         return self._id_to_char[idx]
 
 
-class BaseCharacters:
+class BaseCharacters(BaseVocabulary):
     """🐸BaseCharacters class.
 
         Every new character class should inherit from this.
@@ -175,147 +189,50 @@ class BaseCharacters:
 
     def __init__(
         self,
-        characters: str = None,
-        punctuations: str = None,
-        pad: str = None,
-        eos: str = None,
-        bos: str = None,
-        blank: str = None,
+        characters: str = "",
+        punctuations: str = "",
+        pad: str | None = None,
+        eos: str | None = None,
+        bos: str | None = None,
+        blank: str | None = None,
         *,
         is_unique: bool = False,
         is_sorted: bool = True,
     ) -> None:
-        self._characters = characters
-        self._punctuations = punctuations
-        self._pad = pad
-        self._eos = eos
-        self._bos = bos
-        self._blank = blank
+        super().__init__(vocab=None, pad=pad, blank=blank, bos=bos, eos=eos)
+        self.characters = characters
+        self.punctuations = punctuations
         self.is_unique = is_unique
         self.is_sorted = is_sorted
         self._create_vocab()
 
-    @property
-    def pad_id(self) -> int:
-        return self.char_to_id(self.pad) if self.pad else len(self.vocab)
-
-    @property
-    def blank_id(self) -> int:
-        return self.char_to_id(self.blank) if self.blank else len(self.vocab)
-
-    @property
-    def eos_id(self) -> int:
-        return self.char_to_id(self.eos) if self.eos else len(self.vocab)
-
-    @property
-    def bos_id(self) -> int:
-        return self.char_to_id(self.bos) if self.bos else len(self.vocab)
-
-    @property
-    def characters(self) -> str:
-        return self._characters
-
-    @characters.setter
-    def characters(self, characters: str) -> None:
-        self._characters = characters
-        self._create_vocab()
-
-    @property
-    def punctuations(self) -> str:
-        return self._punctuations
-
-    @punctuations.setter
-    def punctuations(self, punctuations: str) -> None:
-        self._punctuations = punctuations
-        self._create_vocab()
-
-    @property
-    def pad(self) -> str:
-        return self._pad
-
-    @pad.setter
-    def pad(self, pad: str) -> None:
-        self._pad = pad
-        self._create_vocab()
-
-    @property
-    def eos(self) -> str | None:
-        return self._eos
-
-    @eos.setter
-    def eos(self, eos: str | None) -> None:
-        self._eos = eos
-        self._create_vocab()
-
-    @property
-    def bos(self) -> str | None:
-        return self._bos
-
-    @bos.setter
-    def bos(self, bos: str | None) -> None:
-        self._bos = bos
-        self._create_vocab()
-
-    @property
-    def blank(self) -> str | None:
-        return self._blank
-
-    @blank.setter
-    def blank(self, blank: str | None) -> None:
-        self._blank = blank
-        self._create_vocab()
-
-    @property
-    def vocab(self) -> list[str]:
-        return self._vocab
-
-    @vocab.setter
-    def vocab(self, vocab: list[str]) -> None:
-        self._vocab = vocab
-        self._char_to_id = {char: idx for idx, char in enumerate(self.vocab)}
-        self._id_to_char = dict(enumerate(self.vocab))
-
-    @property
-    def num_chars(self) -> int:
-        return len(self._vocab)
-
     def _create_vocab(self) -> None:
-        _vocab = self._characters
+        _vocab = self.characters
         if self.is_unique:
             _vocab = list(set(_vocab))
         if self.is_sorted:
             _vocab = sorted(_vocab)
         _vocab = list(_vocab)
-        _vocab = [self._blank, *_vocab] if self._blank is not None and len(self._blank) > 0 else _vocab
-        _vocab = [self._bos, *_vocab] if self._bos is not None and len(self._bos) > 0 else _vocab
-        _vocab = [self._eos, *_vocab] if self._eos is not None and len(self._eos) > 0 else _vocab
-        _vocab = [self._pad, *_vocab] if self._pad is not None and len(self._pad) > 0 else _vocab
-        self.vocab = _vocab + list(self._punctuations)
+        _vocab = [self.blank, *_vocab] if self.blank is not None and len(self.blank) > 0 else _vocab
+        _vocab = [self.bos, *_vocab] if self.bos is not None and len(self.bos) > 0 else _vocab
+        _vocab = [self.eos, *_vocab] if self.eos is not None and len(self.eos) > 0 else _vocab
+        _vocab = [self.pad, *_vocab] if self.pad is not None and len(self.pad) > 0 else _vocab
+        self.vocab = _vocab + list(self.punctuations)
         if self.is_unique:
             duplicates = {x for x in self.vocab if self.vocab.count(x) > 1}
             assert len(self.vocab) == len(self._char_to_id) == len(self._id_to_char), (
                 f" [!] There are duplicate characters in the character set. {duplicates}"
             )
 
-    def char_to_id(self, char: str) -> int:
-        try:
-            return self._char_to_id[char]
-        except KeyError as e:
-            msg = f" [!] {repr(char)} is not in the vocabulary."
-            raise KeyError(msg) from e
-
-    def id_to_char(self, idx: int) -> str:
-        return self._id_to_char[idx]
-
     def print_log(self, level: int = 0) -> None:
         """Print the vocabulary in a nice format."""
         indent = "\t" * level
-        logger.info("%s| Characters: %s", indent, self._characters)
-        logger.info("%s| Punctuations: %s", indent, self._punctuations)
-        logger.info("%s| Pad: %s", indent, self._pad)
-        logger.info("%s| EOS: %s", indent, self._eos)
-        logger.info("%s| BOS: %s", indent, self._bos)
-        logger.info("%s| Blank: %s", indent, self._blank)
+        logger.info("%s| Characters: %s", indent, self.characters)
+        logger.info("%s| Punctuations: %s", indent, self.punctuations)
+        logger.info("%s| Pad: %s", indent, self.pad)
+        logger.info("%s| EOS: %s", indent, self.eos)
+        logger.info("%s| BOS: %s", indent, self.bos)
+        logger.info("%s| Blank: %s", indent, self.blank)
         logger.info("%s| Vocab: %s", indent, self.vocab)
         logger.info("%s| Num chars: %d", indent, self.num_chars)
 
@@ -335,12 +252,12 @@ class BaseCharacters:
 
     def to_config(self) -> "CharactersConfig":
         return CharactersConfig(
-            characters=self._characters,
-            punctuations=self._punctuations,
-            pad=self._pad,
-            eos=self._eos,
-            bos=self._bos,
-            blank=self._blank,
+            characters=self.characters,
+            punctuations=self.punctuations,
+            pad=self.pad,
+            eos=self.eos,
+            bos=self.bos,
+            blank=self.blank,
             is_unique=self.is_unique,
             is_sorted=self.is_sorted,
         )

--- a/TTS/tts/utils/text/chinese_mandarin/phonemizer.py
+++ b/TTS/tts/utils/text/chinese_mandarin/phonemizer.py
@@ -1,8 +1,5 @@
-try:
-    import pypinyin
-    import spacy_pkuseg as pkuseg
-except ImportError as e:
-    raise ImportError("Chinese requires: spacy_pkuseg, pypinyin") from e
+import pypinyin
+import spacy_pkuseg as pkuseg
 
 from .pinyinToPhonemes import PINYIN_DICT
 

--- a/TTS/tts/utils/text/cleaners.py
+++ b/TTS/tts/utils/text/cleaners.py
@@ -5,6 +5,7 @@ https://github.com/keithito/tacotron/blob/master/text/cleaners.py
 """
 
 import re
+from typing import Protocol, cast
 from unicodedata import normalize
 
 from anyascii import anyascii
@@ -18,6 +19,13 @@ from .french.abbreviations import abbreviations_fr
 from .italian.abbreviations import abbreviations_it
 from .italian.number_norm import normalize_numbers as it_normalize_numbers
 from .italian.time_norm import expand_time_italian
+
+
+class TextCleaner(Protocol):
+    """Protocol that any text cleaner needs to implement."""
+
+    def __call__(self, text: str, lang: str | None) -> str: ...
+
 
 # Regular expression matching whitespace:
 _whitespace_re = re.compile(r"\s+")
@@ -62,7 +70,7 @@ def romanize(text: str, language: str | None = None) -> str:
             msg = "Package not installed: uroman (available in the `languages` extra)"
             raise ImportError(msg) from e
         _uroman = uroman.Uroman()
-    return _uroman.romanize_string(text, lcode=language)
+    return cast(str, _uroman.romanize_string(text, lcode=language))
 
 
 def remove_aux_symbols(text: str) -> str:
@@ -77,7 +85,7 @@ def replace_symbols(text: str, lang: str | None = "en") -> str:
       text:
        Input text.
       lang:
-        Lenguage identifier. ex: "en", "fr", "pt", "ca".
+        Language identifier. ex: "en", "fr", "pt", "ca".
 
     Returns:
       The modified text

--- a/TTS/tts/utils/text/english/number_norm.py
+++ b/TTS/tts/utils/text/english/number_norm.py
@@ -1,10 +1,27 @@
 """from https://github.com/keithito/tacotron"""
 
 import re
+from typing import TYPE_CHECKING, cast
 
-import inflect
+if TYPE_CHECKING:
+    import inflect
 
-_inflect = inflect.engine()
+_inflect = None
+
+
+def _get_inflect() -> "inflect.engine":
+    global _inflect
+    if _inflect is None:
+        import inflect
+
+        _inflect = inflect.engine()
+    return _inflect
+
+
+def _expand_num(n: int) -> str:
+    return cast(str, _get_inflect().number_to_words(n))  # ty: ignore[invalid-argument-type]
+
+
 _comma_number_re = re.compile(r"([0-9][0-9\,]+[0-9])")
 _decimal_number_re = re.compile(r"([0-9]+\.[0-9]+)")
 _currency_re = re.compile(r"(£|\$|¥)([0-9\,\.]*[0-9]+)")
@@ -12,11 +29,11 @@ _ordinal_re = re.compile(r"[0-9]+(st|nd|rd|th)")
 _number_re = re.compile(r"-?[0-9]+")
 
 
-def _remove_commas(m):
+def _remove_commas(m: re.Match) -> str:
     return m.group(1).replace(",", "")
 
 
-def _expand_decimal_point(m):
+def _expand_decimal_point(m: re.Match) -> str:
     return m.group(1).replace(".", " point ")
 
 
@@ -38,7 +55,7 @@ def __expand_currency(value: str, inflection: dict[float, str]) -> str:
     return " ".join(text)
 
 
-def _expand_currency(m: "re.Match") -> str:
+def _expand_currency(m: re.Match) -> str:
     currencies = {
         "$": {
             0.01: "cent",
@@ -70,28 +87,31 @@ def _expand_currency(m: "re.Match") -> str:
     return __expand_currency(value, currency)
 
 
-def _expand_ordinal(m):
-    return _inflect.number_to_words(m.group(0))
+def _expand_ordinal(m: re.Match) -> str:
+    return cast(str, _get_inflect().number_to_words(m.group(0)))
 
 
-def _expand_number(m):
+def _expand_number(m: re.Match) -> str:
+    import inflect
+
+    _inf = _get_inflect()
     num = int(m.group(0))
     if 1000 < num < 3000:
         if num == 2000:
             return "two thousand"
         if 2000 < num < 2010:
-            return "two thousand " + _inflect.number_to_words(num % 100)
+            return "two thousand " + cast(str, _inf.number_to_words(num % 100))  # ty: ignore[invalid-argument-type]
         if num % 100 == 0:
-            return _inflect.number_to_words(num // 100) + " hundred"
-        return _inflect.number_to_words(num, andword="", zero="oh", group=2).replace(", ", " ")
+            return cast(str, _inf.number_to_words(num // 100)) + " hundred"  # ty: ignore[invalid-argument-type]
+        return cast(str, _inf.number_to_words(num, andword="", zero="oh", group=2)).replace(", ", " ")  # ty: ignore[invalid-argument-type]
     try:
-        text = _inflect.number_to_words(num, andword="")
+        text = _inf.number_to_words(num, andword="")  # ty: ignore[invalid-argument-type]
     except inflect.NumOutOfRangeError:
-        text = _inflect.number_to_words(num, group=1).replace(", ", " ")
-    return text
+        text = cast(str, _inf.number_to_words(num, group=1)).replace(", ", " ")  # ty: ignore[invalid-argument-type]
+    return cast(str, text)
 
 
-def normalize_numbers(text):
+def normalize_numbers(text: str) -> str:
     text = re.sub(_comma_number_re, _remove_commas, text)
     text = re.sub(_currency_re, _expand_currency, text)
     text = re.sub(_decimal_number_re, _expand_decimal_point, text)

--- a/TTS/tts/utils/text/english/time_norm.py
+++ b/TTS/tts/utils/text/english/time_norm.py
@@ -1,8 +1,6 @@
 import re
 
-import inflect
-
-_inflect = inflect.engine()
+from TTS.tts.utils.text.english.number_norm import _expand_num
 
 _time_re = re.compile(
     r"""\b
@@ -11,15 +9,11 @@ _time_re = re.compile(
                           ([0-5][0-9])                            # minutes
                           \s*(a\\.m\\.|am|pm|p\\.m\\.|a\\.m|p\\.m)? # am/pm
                           \b""",
-    re.IGNORECASE | re.X,
+    re.IGNORECASE | re.VERBOSE,
 )
 
 
-def _expand_num(n: int) -> str:
-    return _inflect.number_to_words(n)
-
-
-def _expand_time_english(match: "re.Match") -> str:
+def _expand_time_english(match: re.Match) -> str:
     hour = int(match.group(1))
     past_noon = hour >= 12
     time = []

--- a/TTS/tts/utils/text/korean/phonemizer.py
+++ b/TTS/tts/utils/text/korean/phonemizer.py
@@ -18,10 +18,7 @@ def korean_text_to_phonemes(text, character: str = "hangeul") -> str:
     """
     global g2p  # pylint: disable=global-statement
     if g2p is None:
-        try:
-            g2p = kst.G2p()
-        except ImportError as e:
-            raise ImportError("Korean requires: mecab-ko (available in the `ko` extra)") from e
+        g2p = kst.G2p()
 
     text = normalize(text)
     text = g2p(text)
@@ -31,5 +28,5 @@ def korean_text_to_phonemes(text, character: str = "hangeul") -> str:
         from anyascii import anyascii
 
         return anyascii(text)
-    text = list(kst.jamo.hangul_to_jamo(text))  # '하늘' --> ['ᄒ', 'ᅡ', 'ᄂ', 'ᅳ', 'ᆯ']
+    text = kst.jamo.hangul_to_jamo(text)  # '하늘' --> ['ᄒ', 'ᅡ', 'ᄂ', 'ᅳ', 'ᆯ']
     return "".join(text)

--- a/TTS/tts/utils/text/phonemizers/__init__.py
+++ b/TTS/tts/utils/text/phonemizers/__init__.py
@@ -1,71 +1,99 @@
+"""Initialize phonemizers based on installed packages."""
+
 from typing import Any
 
 from TTS.tts.utils.text.phonemizers.base import BasePhonemizer
 from TTS.tts.utils.text.phonemizers.belarusian_phonemizer import BEL_Phonemizer
 from TTS.tts.utils.text.phonemizers.espeak_wrapper import ESpeak
+from TTS.utils.import_utils import PHONEMIZER_DEPS, is_phonemizer_available
 
-try:
-    from TTS.tts.utils.text.phonemizers.gruut_wrapper import Gruut
-except ImportError:
-    Gruut: None = None
-
-try:
-    from TTS.tts.utils.text.phonemizers.bangla_phonemizer import BN_Phonemizer
-except ImportError:
-    BN_Phonemizer: None = None
-
-try:
-    from TTS.tts.utils.text.phonemizers.ja_jp_phonemizer import JA_JP_Phonemizer
-except ImportError:
-    JA_JP_Phonemizer: None = None
-
-try:
-    from TTS.tts.utils.text.phonemizers.ko_kr_phonemizer import KO_KR_Phonemizer
-except ImportError:
-    KO_KR_Phonemizer: None = None
-
-try:
-    from TTS.tts.utils.text.phonemizers.zh_cn_phonemizer import ZH_CN_Phonemizer
-except ImportError:
-    ZH_CN_Phonemizer: None = None
-
-PHONEMIZERS = {b.name(): b for b in (ESpeak, Gruut) if b is not None}
-
-
-ESPEAK_LANGS = list(ESpeak.supported_languages().keys())
-GRUUT_LANGS = [] if Gruut is None else list(Gruut.supported_languages())
+# Dict mapping phonemizer name to its class
+PHONEMIZERS: dict[str, type[BasePhonemizer]] = {}
 
 # Dict setting default phonemizers for each language
-DEF_LANG_TO_PHONEMIZER = {}
-# Add Gruut languages
-if Gruut is not None:
-    DEF_LANG_TO_PHONEMIZER.update({lang: Gruut.name() for lang in GRUUT_LANGS})
-
-# Add ESpeak languages and override any existing ones
-DEF_LANG_TO_PHONEMIZER.update({lang: ESpeak.name() for lang in ESPEAK_LANGS})
-
-# Force default for some languages
-if "en-us" in DEF_LANG_TO_PHONEMIZER:
-    DEF_LANG_TO_PHONEMIZER["en"] = DEF_LANG_TO_PHONEMIZER["en-us"]
-DEF_LANG_TO_PHONEMIZER["be"] = BEL_Phonemizer.name()
+DEF_LANG_TO_PHONEMIZER: dict[str, str] = {}
 
 
-if BN_Phonemizer is not None:
-    PHONEMIZERS[BN_Phonemizer.name()] = BN_Phonemizer
-    DEF_LANG_TO_PHONEMIZER["bn"] = BN_Phonemizer.name()
-if JA_JP_Phonemizer is not None:
-    PHONEMIZERS[JA_JP_Phonemizer.name()] = JA_JP_Phonemizer
-    DEF_LANG_TO_PHONEMIZER["ja-jp"] = JA_JP_Phonemizer.name()
-if KO_KR_Phonemizer is not None:
-    PHONEMIZERS[KO_KR_Phonemizer.name()] = KO_KR_Phonemizer
-    DEF_LANG_TO_PHONEMIZER["ko-kr"] = KO_KR_Phonemizer.name()
-if ZH_CN_Phonemizer is not None:
-    PHONEMIZERS[ZH_CN_Phonemizer.name()] = ZH_CN_Phonemizer
-    DEF_LANG_TO_PHONEMIZER["zh-cn"] = ZH_CN_Phonemizer.name()
+def _register_bangla() -> None:
+    """Register the Bangla phonemizer if available."""
+    if is_phonemizer_available("bn_phonemizer"):
+        from TTS.tts.utils.text.phonemizers.bangla_phonemizer import BN_Phonemizer  # noqa: PLC0415
+
+        DEF_LANG_TO_PHONEMIZER["bn"] = BN_Phonemizer.name()
+        PHONEMIZERS[BN_Phonemizer.name()] = BN_Phonemizer
+
+
+def _register_chinese() -> None:
+    """Register the Chinese phonemizer if available."""
+    if is_phonemizer_available("zh_cn_phonemizer"):
+        from TTS.tts.utils.text.phonemizers.zh_cn_phonemizer import ZH_CN_Phonemizer  # noqa: PLC0415
+
+        DEF_LANG_TO_PHONEMIZER["zh-cn"] = ZH_CN_Phonemizer.name()
+        PHONEMIZERS[ZH_CN_Phonemizer.name()] = ZH_CN_Phonemizer
+
+
+def _register_espeak() -> None:
+    """Register ESpeak and its supported languages."""
+    DEF_LANG_TO_PHONEMIZER.update({lang: ESpeak.name() for lang in ESpeak.supported_languages()})
+    PHONEMIZERS[ESpeak.name()] = ESpeak
+
+
+def _register_gruut() -> None:
+    """Register Gruut and its supported languages if available."""
+    if is_phonemizer_available("gruut"):
+        from TTS.tts.utils.text.phonemizers.gruut_wrapper import Gruut  # noqa: PLC0415
+
+        DEF_LANG_TO_PHONEMIZER.update({lang: Gruut.name() for lang in Gruut.supported_languages()})
+        PHONEMIZERS[Gruut.name()] = Gruut
+
+
+def _register_japanese() -> None:
+    """Register the Japanese phonemizer if available."""
+    if is_phonemizer_available("ja_jp_phonemizer"):
+        from TTS.tts.utils.text.phonemizers.ja_jp_phonemizer import JA_JP_Phonemizer  # noqa: PLC0415
+
+        DEF_LANG_TO_PHONEMIZER["ja-jp"] = JA_JP_Phonemizer.name()
+        PHONEMIZERS[JA_JP_Phonemizer.name()] = JA_JP_Phonemizer
+
+
+def _register_korean() -> None:
+    """Register the Korean phonemizer if available."""
+    if is_phonemizer_available("ko_kr_phonemizer"):
+        from TTS.tts.utils.text.phonemizers.ko_kr_phonemizer import KO_KR_Phonemizer  # noqa: PLC0415
+
+        DEF_LANG_TO_PHONEMIZER["ko-kr"] = KO_KR_Phonemizer.name()
+        PHONEMIZERS[KO_KR_Phonemizer.name()] = KO_KR_Phonemizer
+
+
+def _register_phonemizers() -> None:
+    if len(DEF_LANG_TO_PHONEMIZER) == 0:
+        _register_gruut()
+        _register_espeak()  # override existing Gruut languages
+
+        # Force default for some languages
+        if "en-us" in DEF_LANG_TO_PHONEMIZER:
+            DEF_LANG_TO_PHONEMIZER["en"] = DEF_LANG_TO_PHONEMIZER["en-us"]
+        DEF_LANG_TO_PHONEMIZER["be"] = BEL_Phonemizer.name()
+        PHONEMIZERS[BEL_Phonemizer.name()] = BEL_Phonemizer
+
+        _register_bangla()
+        _register_japanese()
+        _register_korean()
+        _register_chinese()
+
+
+def get_default_phonemizer(language: str | None) -> str:
+    """Return the name of the default phonemizer for the given language."""
+    _register_phonemizers()
+
+    if language not in DEF_LANG_TO_PHONEMIZER:
+        msg = f"No phonemizer found for language {language}. You may need to install a third party library for it."
+        raise ValueError(msg)
+    return DEF_LANG_TO_PHONEMIZER[language]
 
 
 def get_phonemizer_by_name(name: str, **kwargs: Any) -> BasePhonemizer:
-    """Initiate a phonemizer by name
+    """Initialize a phonemizer by name.
 
     Args:
         name (str):
@@ -73,33 +101,12 @@ def get_phonemizer_by_name(name: str, **kwargs: Any) -> BasePhonemizer:
 
         kwargs (dict):
             Extra keyword arguments that should be passed to the phonemizer.
+
     """
-    if name == "espeak":
-        return ESpeak(**kwargs)
-    if name == "gruut":
-        if Gruut is None:
-            raise ImportError("You need to install the Gruut phonemizer. Try `pip install coqui-tts[languages]`")
-        return Gruut(**kwargs)
-    if name == "zh_cn_phonemizer":
-        if ZH_CN_Phonemizer is None:
-            raise ImportError("You need to install ZH phonemizer dependencies. Try `pip install coqui-tts[zh]`")
-        return ZH_CN_Phonemizer(**kwargs)
-    if name == "ja_jp_phonemizer":
-        if JA_JP_Phonemizer is None:
-            raise ImportError("You need to install JA phonemizer dependencies. Try `pip install coqui-tts[ja]`")
-        return JA_JP_Phonemizer(**kwargs)
-    if name == "ko_kr_phonemizer":
-        if KO_KR_Phonemizer is None:
-            raise ImportError("You need to install KO phonemizer dependencies. Try `pip install coqui-tts[ko]`")
-        return KO_KR_Phonemizer(**kwargs)
-    if name == "bn_phonemizer":
-        if BN_Phonemizer is None:
-            raise ImportError("You need to install BN phonemizer dependencies. Try `pip install coqui-tts[bn]`")
-        return BN_Phonemizer(**kwargs)
-    if name == "be_phonemizer":
-        return BEL_Phonemizer(**kwargs)
-    raise ValueError(f"Phonemizer {name} not found")
-
-
-if __name__ == "__main__":
-    print(DEF_LANG_TO_PHONEMIZER)
+    _register_phonemizers()
+    if name in PHONEMIZER_DEPS and not is_phonemizer_available(name):
+        raise ImportError(PHONEMIZER_DEPS[name].import_error(name))
+    if name not in PHONEMIZERS:
+        msg = f"Phonemizer {name} not found"
+        raise ValueError(msg)
+    return PHONEMIZERS[name](**kwargs)

--- a/TTS/tts/utils/text/phonemizers/multi_phonemizer.py
+++ b/TTS/tts/utils/text/phonemizers/multi_phonemizer.py
@@ -39,8 +39,8 @@ class MultiPhonemizer:
     def name() -> str:
         return "multi-phonemizer"
 
-    def phonemize(self, text: str, separator: str = "|", language: str = "") -> str:
-        if language == "":
+    def phonemize(self, text: str, separator: str = "|", language: str | None = None) -> str:
+        if language is None:
             raise ValueError("Language must be set for multi-phonemizer to phonemize.")
         return self.lang_to_phonemizer[language].phonemize(text, separator)
 

--- a/TTS/tts/utils/text/phonemizers/multi_phonemizer.py
+++ b/TTS/tts/utils/text/phonemizers/multi_phonemizer.py
@@ -1,39 +1,30 @@
 import logging
 
-from TTS.tts.utils.text.phonemizers import DEF_LANG_TO_PHONEMIZER, get_phonemizer_by_name
-from TTS.tts.utils.text.phonemizers.base import BasePhonemizer
+from TTS.tts.utils.text.phonemizers import get_default_phonemizer, get_phonemizer_by_name
 
 logger = logging.getLogger(__name__)
 
 
 class MultiPhonemizer:
-    """🐸TTS multi-phonemizer that operates phonemizers for multiple langugages
+    """🐸TTS multi-phonemizer that operates phonemizers for multiple languages.
 
     Args:
         custom_lang_to_phonemizer (Dict):
             Custom phonemizer mapping if you want to change the defaults. In the format of
-            `{"lang_code", "phonemizer_name"}`. When it is None, `DEF_LANG_TO_PHONEMIZER` is used. Defaults to `{}`.
+            `{"lang_code", "phonemizer_name"}`. When the phonemizer name is
+            None, a default phonemizer is used. Defaults to `{}`.
 
     TODO: find a way to pass custom kwargs to the phonemizers
     """
 
-    def __init__(self, lang_to_phonemizer_name: dict[str, str] | None = None) -> None:
+    def __init__(self, lang_to_phonemizer_name: dict[str, str | None] | None = None) -> None:
+        self.lang_to_phonemizer = {}
         if lang_to_phonemizer_name is None:
             lang_to_phonemizer_name = {}
-        for k, v in lang_to_phonemizer_name.items():
-            if v == "" and k in DEF_LANG_TO_PHONEMIZER:
-                lang_to_phonemizer_name[k] = DEF_LANG_TO_PHONEMIZER[k]
-            elif v == "":
-                raise ValueError(f"Phonemizer wasn't set for language {k} and doesn't have a default.")
-        self.lang_to_phonemizer_name = lang_to_phonemizer_name
-        self.lang_to_phonemizer = self.init_phonemizers(self.lang_to_phonemizer_name)
-
-    @staticmethod
-    def init_phonemizers(lang_to_phonemizer_name: dict[str, str]) -> dict[str, BasePhonemizer]:
-        lang_to_phonemizer = {}
-        for k, v in lang_to_phonemizer_name.items():
-            lang_to_phonemizer[k] = get_phonemizer_by_name(v, language=k)
-        return lang_to_phonemizer
+        for lang, name in lang_to_phonemizer_name.items():
+            if not name:
+                name = get_default_phonemizer(lang)
+            self.lang_to_phonemizer[lang] = get_phonemizer_by_name(name, language=lang)
 
     @staticmethod
     def name() -> str:

--- a/TTS/tts/utils/text/tokenizer.py
+++ b/TTS/tts/utils/text/tokenizer.py
@@ -193,7 +193,7 @@ class TTSTokenizer:
             characters, new_config = characters.init_from_config(config)
 
         # set characters class
-        new_config.characters.characters_class = get_import_path(characters)
+        new_config.characters.characters_class = get_import_path(characters)  # ty: ignore[invalid-assignment]
 
         # init phonemizer
         phonemizer = None

--- a/TTS/tts/utils/text/tokenizer.py
+++ b/TTS/tts/utils/text/tokenizer.py
@@ -1,10 +1,10 @@
 import logging
-from collections.abc import Callable
-from typing import Union
 
+from TTS.tts.configs.shared_configs import BaseTTSConfig
 from TTS.tts.utils.text import cleaners
 from TTS.tts.utils.text.characters import BaseCharacters, Graphemes, IPAPhonemes
 from TTS.tts.utils.text.phonemizers import DEF_LANG_TO_PHONEMIZER, get_phonemizer_by_name
+from TTS.tts.utils.text.phonemizers.base import BasePhonemizer
 from TTS.tts.utils.text.phonemizers.multi_phonemizer import MultiPhonemizer
 from TTS.utils.generic_utils import get_import_path, import_class
 
@@ -30,44 +30,51 @@ class TTSTokenizer:
             A phonemizer object or a dict that maps language codes to phonemizer objects. Defaults to None.
 
     Example:
-
         >>> from TTS.tts.utils.text.tokenizer import TTSTokenizer
         >>> tokenizer = TTSTokenizer(use_phonemes=False, characters=Graphemes())
         >>> text = "Hello world!"
         >>> ids = tokenizer.text_to_ids(text)
         >>> text_hat = tokenizer.ids_to_text(ids)
         >>> assert text == text_hat
+
     """
 
     def __init__(
         self,
+        *,
         use_phonemes: bool = False,
-        text_cleaner: Callable[[str], str] | None = None,
-        characters: BaseCharacters | None = None,
-        phonemizer: Union["Phonemizer", dict] | None = None,
+        text_cleaner: cleaners.TextCleaner | None = None,
+        characters: BaseCharacters,
+        phonemizer: BasePhonemizer | MultiPhonemizer | None = None,
         add_blank: bool = False,
         use_eos_bos: bool = False,
-    ):
-        self.text_cleaner = text_cleaner
+    ) -> None:
+        self.phonemizer = None
         self.use_phonemes = use_phonemes
+        if use_phonemes:
+            self.phonemizer = phonemizer
+            if self.phonemizer is None:
+                msg = "Need to specify a phonemizer when `use_phonemes==True`"
+                raise ValueError(msg)
+        self.text_cleaner = text_cleaner
         self.add_blank = add_blank
         self.use_eos_bos = use_eos_bos
         self.characters = characters
         self.not_found_characters = []
-        self.phonemizer = phonemizer
 
     @property
-    def characters(self):
+    def characters(self) -> BaseCharacters:
+        """Return character set."""
         return self._characters
 
     @characters.setter
-    def characters(self, new_characters):
+    def characters(self, new_characters: BaseCharacters) -> None:
         self._characters = new_characters
         self.pad_id = self.characters.char_to_id(self.characters.pad) if self.characters.pad else None
         self.blank_id = self.characters.char_to_id(self.characters.blank) if self.characters.blank else None
 
     def encode(self, text: str) -> list[int]:
-        """Encodes a string of text as a sequence of IDs."""
+        """Encode a string of text as a sequence of IDs."""
         token_ids = []
         for char in text:
             try:
@@ -82,14 +89,14 @@ class TTSTokenizer:
         return token_ids
 
     def decode(self, token_ids: list[int]) -> str:
-        """Decodes a sequence of IDs to a string of text."""
+        """Decode a sequence of IDs to a string of text."""
         text = ""
         for token_id in token_ids:
             text += self.characters.id_to_char(token_id)
         return text
 
-    def text_to_ids(self, text: str, language: str | None = None) -> list[int]:  # pylint: disable=unused-argument
-        """Converts a string of text to a sequence of token IDs.
+    def text_to_ids(self, text: str, language: str | None = None) -> list[int]:
+        """Convert a string of text to a sequence of token IDs.
 
         Args:
             text(str):
@@ -112,36 +119,36 @@ class TTSTokenizer:
         if self.text_cleaner is not None:
             text = self.text_cleaner(text)
             logger.debug("Cleaned text: %s", text)
-        if self.use_phonemes:
+        if self.phonemizer:
             text = self.phonemizer.phonemize(text, separator="", language=language)
             logger.debug("Phonemes: %s", text)
-        text = self.encode(text)
+        token_ids = self.encode(text)
         if self.add_blank:
-            text = self.intersperse_blank_char(text)
+            token_ids = self.intersperse_blank_char(token_ids)
         if self.use_eos_bos:
-            text = self.pad_with_bos_eos(text)
-        return text
+            token_ids = self.pad_with_bos_eos(token_ids)
+        return token_ids
 
     def ids_to_text(self, id_sequence: list[int]) -> str:
-        """Converts a sequence of token IDs to a string of text."""
+        """Convert a sequence of token IDs to a string of text."""
         return self.decode(id_sequence)
 
-    def pad_with_bos_eos(self, char_sequence: list[str]):
-        """Pads a sequence with the special BOS and EOS characters."""
-        return [self.characters.bos_id] + list(char_sequence) + [self.characters.eos_id]
+    def pad_with_bos_eos(self, char_sequence: list[int]) -> list[int]:
+        """Pad a sequence with the special BOS and EOS character IDs."""
+        return [self.characters.bos_id, *char_sequence, self.characters.eos_id]
 
-    def intersperse_blank_char(self, char_sequence: list[str]):
-        """Intersperses the blank character between characters in a sequence."""
+    def intersperse_blank_char(self, char_sequence: list[int]) -> list[int]:
+        """Intersperses the blank character ID between characters IDs in a sequence."""
         result = [self.characters.blank_id] * (len(char_sequence) * 2 + 1)
         result[1::2] = char_sequence
         return result
 
-    def print_logs(self, level: int = 0):
+    def print_logs(self, level: int = 0) -> None:
         indent = "\t" * level
         logger.info("%s| add_blank: %s", indent, self.add_blank)
         logger.info("%s| use_eos_bos: %s", indent, self.use_eos_bos)
         logger.info("%s| use_phonemes: %s", indent, self.use_phonemes)
-        if self.use_phonemes:
+        if self.phonemizer:
             logger.info("%s| phonemizer:", indent)
             self.phonemizer.print_logs(level + 1)
         if len(self.not_found_characters) > 0:
@@ -150,13 +157,16 @@ class TTSTokenizer:
                 logger.info("%s| %s", indent, char)
 
     @staticmethod
-    def init_from_config(config: "Coqpit", characters: BaseCharacters | None = None):
-        """Init Tokenizer object from config
+    def init_from_config(
+        config: BaseTTSConfig, characters: BaseCharacters | None = None
+    ) -> tuple["TTSTokenizer", BaseTTSConfig]:
+        """Init Tokenizer object from config.
 
         Args:
             config (Coqpit): Coqpit model config.
             characters (BaseCharacters): Defines the model character set. If not set, use the default options based on
                 the config values. Defaults to None.
+
         """
         # init cleaners
         text_cleaner = None
@@ -173,14 +183,12 @@ class TTSTokenizer:
                     raise TypeError(msg)
                 characters, new_config = CharactersClass.init_from_config(config)
             # set characters based on config
+            elif config.use_phonemes:
+                # init default phoneme set
+                characters, new_config = IPAPhonemes().init_from_config(config)
             else:
-                if config.use_phonemes:
-                    # init phoneme set
-                    characters, new_config = IPAPhonemes().init_from_config(config)
-                else:
-                    # init character set
-                    characters, new_config = Graphemes().init_from_config(config)
-
+                # init default character set
+                characters, new_config = Graphemes().init_from_config(config)
         else:
             characters, new_config = characters.init_from_config(config)
 
@@ -196,7 +204,8 @@ class TTSTokenizer:
                     if dataset.language != "":
                         lang_to_phonemizer_name[dataset.language] = dataset.phonemizer
                     else:
-                        raise ValueError("Multi phonemizer requires language to be set for each dataset.")
+                        msg = "Multi phonemizer requires language to be set for each dataset."
+                        raise ValueError(msg)
                 phonemizer = MultiPhonemizer(lang_to_phonemizer_name)
             else:
                 phonemizer_kwargs = {"language": config.phoneme_language}
@@ -209,14 +218,18 @@ class TTSTokenizer:
                         )
                         new_config.phonemizer = phonemizer.name()
                     except KeyError as e:
-                        raise ValueError(
-                            f"""No phonemizer found for language {config.phoneme_language}.
+                        msg = f"""No phonemizer found for language {config.phoneme_language}.
                             You may need to install a third party library for this language."""
-                        ) from e
+                        raise ValueError(msg) from e
 
         return (
             TTSTokenizer(
-                config.use_phonemes, text_cleaner, characters, phonemizer, config.add_blank, config.enable_eos_bos_chars
+                use_phonemes=config.use_phonemes,
+                text_cleaner=text_cleaner,
+                characters=characters,
+                phonemizer=phonemizer,
+                add_blank=config.add_blank,
+                use_eos_bos=config.enable_eos_bos_chars,
             ),
             new_config,
         )

--- a/TTS/tts/utils/text/tokenizer.py
+++ b/TTS/tts/utils/text/tokenizer.py
@@ -3,7 +3,7 @@ import logging
 from TTS.tts.configs.shared_configs import BaseTTSConfig
 from TTS.tts.utils.text import cleaners
 from TTS.tts.utils.text.characters import BaseCharacters, Graphemes, IPAPhonemes
-from TTS.tts.utils.text.phonemizers import DEF_LANG_TO_PHONEMIZER, get_phonemizer_by_name
+from TTS.tts.utils.text.phonemizers import get_default_phonemizer, get_phonemizer_by_name
 from TTS.tts.utils.text.phonemizers.base import BasePhonemizer
 from TTS.tts.utils.text.phonemizers.multi_phonemizer import MultiPhonemizer
 from TTS.utils.generic_utils import get_import_path, import_class
@@ -212,15 +212,10 @@ class TTSTokenizer:
                 if "phonemizer" in config and config.phonemizer:
                     phonemizer = get_phonemizer_by_name(config.phonemizer, **phonemizer_kwargs)
                 else:
-                    try:
-                        phonemizer = get_phonemizer_by_name(
-                            DEF_LANG_TO_PHONEMIZER[config.phoneme_language], **phonemizer_kwargs
-                        )
-                        new_config.phonemizer = phonemizer.name()
-                    except KeyError as e:
-                        msg = f"""No phonemizer found for language {config.phoneme_language}.
-                            You may need to install a third party library for this language."""
-                        raise ValueError(msg) from e
+                    phonemizer = get_phonemizer_by_name(
+                        get_default_phonemizer(config.phoneme_language), **phonemizer_kwargs
+                    )
+                    new_config.phonemizer = phonemizer.name()
 
         return (
             TTSTokenizer(

--- a/TTS/utils/audio/numpy_transforms.py
+++ b/TTS/utils/audio/numpy_transforms.py
@@ -8,7 +8,6 @@ import librosa
 import numpy as np
 import scipy
 import soundfile as sf
-from librosa import effects, filters, magphase, pyin
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +32,7 @@ def build_mel_basis(
     if mel_fmax is not None:
         assert mel_fmax <= sample_rate // 2
         assert mel_fmax - mel_fmin > 0
-    return filters.mel(sr=sample_rate, n_fft=fft_size, n_mels=num_mels, fmin=mel_fmin, fmax=mel_fmax)
+    return librosa.filters.mel(sr=sample_rate, n_fft=fft_size, n_mels=num_mels, fmin=mel_fmin, fmax=mel_fmax)
 
 
 def millisec_to_length(*, frame_length_ms: float, frame_shift_ms: float, sample_rate: int, **kwargs) -> tuple[int, int]:
@@ -290,7 +289,7 @@ def compute_f0(
         pitch_fmin = sample_rate / (win_length - 1) + 0.1
         logger.warning("pitch_fmin increased to %f", pitch_fmin)
 
-    f0, voiced_mask, _ = pyin(
+    f0, voiced_mask, _ = librosa.pyin(
         y=x.astype(np.double),
         fmin=pitch_fmin,
         fmax=pitch_fmax,
@@ -328,7 +327,7 @@ def compute_energy(y: np.ndarray, **kwargs) -> np.ndarray:
       >>> energy = ap.compute_energy(wav)
     """
     x = stft(y=y, **kwargs)
-    mag, _ = magphase(x)
+    mag, _ = librosa.magphase(x)
     return np.sqrt(np.sum(mag**2, axis=0))
 
 
@@ -376,7 +375,7 @@ def trim_silence(
     """Trim silent parts with a threshold and 0.01 sec margin."""
     margin = int(sample_rate * 0.01)
     wav = wav[margin:-margin]
-    return effects.trim(wav, top_db=trim_db, frame_length=win_length, hop_length=hop_length)[0]
+    return librosa.effects.trim(wav, top_db=trim_db, frame_length=win_length, hop_length=hop_length)[0]
 
 
 def volume_norm(*, x: np.ndarray, coef: float = 0.95, **kwargs) -> np.ndarray:

--- a/TTS/utils/import_utils.py
+++ b/TTS/utils/import_utils.py
@@ -7,6 +7,7 @@ https://github.com/huggingface/transformers/blob/main/src/transformers/utils/imp
 import importlib.metadata
 import importlib.util
 import logging
+from dataclasses import dataclass
 from functools import lru_cache
 from typing import Literal, overload
 
@@ -30,6 +31,47 @@ found in your environment. You can install it with Coqui's `codec` extra:
 pip install coqui-tts[codec]
 ```
 """
+
+
+@dataclass(frozen=True)
+class PhonemizeDeps:
+    """Dependencies for a phonemizer."""
+
+    packages: list[str]
+    extra: str
+
+    def import_error(self, name: str) -> str:
+        packages_str = ", ".join(self.packages)
+        return f"""
+Phonemizer `{name}` requires: {packages_str}. Install with Coqui's `{self.extra}` extra:
+```
+pip install coqui-tts[{self.extra}]
+```
+"""
+
+
+PHONEMIZER_DEPS: dict[str, PhonemizeDeps] = {
+    "bn_phonemizer": PhonemizeDeps(["bangla", "bnnumerizer", "bnunicodenormalizer"], "bn"),
+    "gruut": PhonemizeDeps(
+        [
+            "gruut",
+        ],
+        "languages",
+    ),
+    "ja_jp_phonemizer": PhonemizeDeps(
+        [
+            "fugashi",
+        ],
+        "ja",
+    ),
+    "ko_kr_phonemizer": PhonemizeDeps(
+        [
+            "mecab-ko",
+        ],
+        "ko",
+    ),
+    "zh_cn_phonemizer": PhonemizeDeps(["pypinyin", "spacy_pkuseg"], "zh"),
+}
 
 
 @overload
@@ -98,3 +140,12 @@ def is_torchaudio_available() -> bool:
 def is_torchcodec_available() -> bool:
     """Return whether Torchcodec is available in the environment."""
     return _is_package_available("torchcodec")
+
+
+@lru_cache
+def is_phonemizer_available(phonemizer: str) -> bool:
+    """Return whether packages for the given phonemizer are available in the environment."""
+    if phonemizer not in PHONEMIZER_DEPS:
+        msg = f"Not a valid phonemizer name: {phonemizer}"
+        raise ValueError(msg)
+    return all(_is_package_available(p) for p in PHONEMIZER_DEPS[phonemizer].packages)

--- a/TTS/utils/import_utils.py
+++ b/TTS/utils/import_utils.py
@@ -1,3 +1,21 @@
+"""Utilities to check availability of packages.
+
+Largely adapted from:
+https://github.com/huggingface/transformers/blob/main/src/transformers/utils/import_utils.py
+"""
+
+import importlib.metadata
+import importlib.util
+import logging
+from functools import lru_cache
+from typing import Literal, overload
+
+from packaging import version
+
+logger = logging.getLogger(__name__)
+
+PACKAGE_DISTRIBUTION_MAPPING = importlib.metadata.packages_distributions()
+
 PYTORCH_IMPORT_ERROR = """
 Coqui TTS requires the PyTorch and Torchaudio libraries but they were not found in your
 environment. Check out the instructions on the installation page:
@@ -6,8 +24,77 @@ and follow the ones that match your environment.
 """
 
 TORCHCODEC_IMPORT_ERROR = """
-From Pytorch 2.9, the torchcodec library is required for audio IO, but it was not found in your environment. You can install it with Coqui's `codec` extra:
+From Pytorch 2.9, the torchcodec library is required for audio IO, but it was not
+found in your environment. You can install it with Coqui's `codec` extra:
 ```
 pip install coqui-tts[codec]
 ```
 """
+
+
+@overload
+def _is_package_available(pkg_name: str, *, return_version: Literal[False] = False) -> bool: ...
+@overload
+def _is_package_available(pkg_name: str, *, return_version: Literal[True]) -> tuple[bool, str]: ...
+def _is_package_available(pkg_name: str, *, return_version: bool = False):
+    """Check if `pkg_name` exist, and optionally try to get its version."""
+    spec = importlib.util.find_spec(pkg_name)
+    package_exists = spec is not None
+    package_version = "N/A"
+    if package_exists and return_version:
+        try:
+            # importlib.metadata works with the distribution package, which may be different from the import
+            # name (e.g. `PIL` is the import name, but `pillow` is the distribution name)
+            distributions = PACKAGE_DISTRIBUTION_MAPPING[pkg_name]
+            # Per PEP 503, underscores and hyphens are equivalent in package names.
+            # Prefer the distribution that matches the (normalized) package name.
+            normalized_pkg_name = pkg_name.replace("_", "-")
+            if normalized_pkg_name in distributions:
+                distribution_name = normalized_pkg_name
+            elif pkg_name in distributions:
+                distribution_name = pkg_name
+            else:
+                distribution_name = distributions[0]
+            package_version = importlib.metadata.version(distribution_name)
+        except (importlib.metadata.PackageNotFoundError, KeyError):
+            # If we cannot find the metadata (because of editable install for example), try to import directly.
+            # Note that this branch will almost never be run, so we do not import packages for nothing here
+            package = importlib.import_module(pkg_name)
+            package_version = getattr(package, "__version__", "N/A")
+        logger.debug("Detected %s version: %s", pkg_name, package_version)
+    if return_version:
+        return package_exists, package_version
+    return package_exists
+
+
+@lru_cache
+def is_torch_available() -> bool:
+    """Return whether PyTorch is available in the environment."""
+    return _is_package_available("torch")
+
+
+@lru_cache
+def get_torch_version() -> str:
+    """Return the PyTorch version."""
+    _, torch_version = _is_package_available("torch", return_version=True)
+    return torch_version
+
+
+@lru_cache
+def is_torch_greater_or_equal(library_version: str) -> bool:
+    """Return True if the current PyTorch version is greater than or equal to the given version."""
+    if not is_torch_available():
+        return False
+    return version.parse(get_torch_version()) >= version.parse(library_version)
+
+
+@lru_cache
+def is_torchaudio_available() -> bool:
+    """Return whether Torchaudio is available in the environment."""
+    return _is_package_available("torchaudio")
+
+
+@lru_cache
+def is_torchcodec_available() -> bool:
+    """Return whether Torchcodec is available in the environment."""
+    return _is_package_available("torchcodec")

--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -45,7 +45,6 @@ class Synthesizer(nn.Module):
         tts_checkpoint: str | os.PathLike[Any] | None = None,
         tts_config_path: str | os.PathLike[Any] | None = None,
         tts_speakers_file: str | os.PathLike[Any] | None = None,
-        tts_languages_file: str | os.PathLike[Any] | None = None,
         vocoder_checkpoint: str | os.PathLike[Any] | None = None,
         vocoder_config: str | os.PathLike[Any] | None = None,
         encoder_checkpoint: str | os.PathLike[Any] | None = None,
@@ -83,7 +82,6 @@ class Synthesizer(nn.Module):
         self.tts_checkpoint = Path(optional_to_str(tts_checkpoint))
         self.tts_config_path = Path(optional_to_str(tts_config_path))
         self.tts_speakers_file = optional_to_str(tts_speakers_file)
-        self.tts_languages_file = optional_to_str(tts_languages_file)
         self.vocoder_checkpoint = optional_to_str(vocoder_checkpoint)
         self.vocoder_config = optional_to_str(vocoder_config)
         self.encoder_checkpoint = optional_to_str(encoder_checkpoint)

--- a/TTS/vc/layers/freevc/mel_processing.py
+++ b/TTS/vc/layers/freevc/mel_processing.py
@@ -1,8 +1,8 @@
 import logging
 
+import librosa
 import torch
 import torch.utils.data
-from librosa.filters import mel as librosa_mel_fn
 
 from TTS.utils.audio.torch_transforms import amp_to_db
 
@@ -25,7 +25,7 @@ def mel_spectrogram_torch(y, n_fft, num_mels, sampling_rate, hop_size, win_size,
     fmax_dtype_device = str(fmax) + "_" + dtype_device
     wnsize_dtype_device = str(win_size) + "_" + dtype_device
     if fmax_dtype_device not in mel_basis:
-        mel = librosa_mel_fn(sr=sampling_rate, n_fft=n_fft, n_mels=num_mels, fmin=fmin, fmax=fmax)
+        mel = librosa.filters.mel(sr=sampling_rate, n_fft=n_fft, n_mels=num_mels, fmin=fmin, fmax=fmax)
         mel_basis[fmax_dtype_device] = torch.from_numpy(mel).to(dtype=y.dtype, device=y.device)
     if wnsize_dtype_device not in hann_window:
         hann_window[wnsize_dtype_device] = torch.hann_window(win_size).to(dtype=y.dtype, device=y.device)

--- a/TTS/vocoder/layers/pqmf.py
+++ b/TTS/vocoder/layers/pqmf.py
@@ -1,7 +1,7 @@
 import numpy as np
+import scipy
 import torch
 import torch.nn.functional as F
-from scipy import signal as sig
 
 
 # adapted from
@@ -15,7 +15,7 @@ class PQMF(torch.nn.Module):
         self.cutoff = cutoff
         self.beta = beta
 
-        QMF = sig.firwin(taps + 1, cutoff, window=("kaiser", beta))
+        QMF = scipy.signal.firwin(taps + 1, cutoff, window=("kaiser", beta))
         H = np.zeros((N, len(QMF)))
         G = np.zeros((N, len(QMF)))
         for k in range(N):

--- a/TTS/vocoder/models/wavernn.py
+++ b/TTS/vocoder/models/wavernn.py
@@ -9,7 +9,6 @@ from torch import nn
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 
-from TTS.tts.utils.visual import plot_spectrogram
 from TTS.utils.audio import AudioProcessor
 from TTS.utils.audio.numpy_transforms import mulaw_decode
 from TTS.vocoder.configs import WavernnConfig
@@ -508,6 +507,8 @@ class Wavernn(BaseVocoder):
         test_loader: "DataLoader",
         output: dict,  # pylint: disable=unused-argument
     ) -> tuple[dict, dict]:
+        from TTS.tts.utils.visual import plot_spectrogram
+
         ap = self.ap
         figures = {}
         audios = {}

--- a/TTS/vocoder/utils/generic_utils.py
+++ b/TTS/vocoder/utils/generic_utils.py
@@ -2,9 +2,7 @@ import logging
 
 import numpy as np
 import torch
-from matplotlib import pyplot as plt
 
-from TTS.tts.utils.visual import plot_spectrogram
 from TTS.utils.audio import AudioProcessor
 
 logger = logging.getLogger(__name__)
@@ -31,7 +29,7 @@ def interpolate_vocoder_input(scale_factor, spec):
     return spec
 
 
-def plot_results(y_hat: torch.tensor, y: torch.tensor, ap: AudioProcessor, name_prefix: str = None) -> dict:
+def plot_results(y_hat: torch.tensor, y: torch.tensor, ap: AudioProcessor, name_prefix: str | None = None) -> dict:
     """Plot the predicted and the real waveform and their spectrograms.
 
     Args:
@@ -43,6 +41,10 @@ def plot_results(y_hat: torch.tensor, y: torch.tensor, ap: AudioProcessor, name_
     Returns:
         Dict: output figures keyed by the name of the figures.
     """
+    from matplotlib import pyplot as plt
+
+    from TTS.tts.utils.visual import plot_spectrogram
+
     if name_prefix is None:
         name_prefix = ""
 

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -22,10 +22,13 @@ WORKDIR /app
 
 # Install dependencies first for better caching
 COPY pyproject.toml /app
-RUN uv pip install -r pyproject.toml --extra all --group dev --torch-backend=cu128
+RUN uv pip install -r pyproject.toml --extra all --extra cuda --extra codec --group dev
 
 # Copy the rest of the application
 COPY . /app
 
 # Install the project
 RUN uv pip install -e .
+
+# Verify installation works
+RUN uv run --active python -c "from TTS.api import TTS"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
     "matplotlib>=3.8.4",
     # Coqui stack
     "coqui-tts-trainer>=0.3.0,<0.4.0",
-    "coqpit-config>=0.2.3,<0.3.0",
+    "coqpit-config>=0.2.4,<0.3.0",
     "monotonic-alignment-search>=0.1.0",
     "ko-speech-tools>=0.1.0",
     # Tortoise

--- a/tests/integration/test_vits.py
+++ b/tests/integration/test_vits.py
@@ -72,7 +72,19 @@ def test_train_step(encoder_sample_rate, interpolate_z, upsample_rates, sample_r
     - upsampling: Upsampling by the decoder upsampling layers
     - upsampling_interpolation: Upsampling by interpolation
     """
-    model_args = VitsArgs(num_chars=32, spec_segment_size=10)
+    # Use much smaller model for integration tests to reduce memory usage
+    model_args = VitsArgs(
+        num_chars=32,
+        spec_segment_size=10,
+        # Reduce model width (channels)
+        hidden_channels=64,  # default: 192
+        hidden_channels_ffn_text_encoder=256,  # default: 768
+        upsample_initial_channel_decoder=128,  # default: 512
+        # Reduce model depth (layers)
+        num_layers_text_encoder=2,  # default: 6
+        num_layers_posterior_encoder=4,  # default: 16
+        num_layers_flow=2,  # default: 4
+    )
 
     if encoder_sample_rate is not None:
         model_args.encoder_sample_rate = encoder_sample_rate

--- a/tests/integration/test_vits_multilingual_speaker_emb_train.py
+++ b/tests/integration/test_vits_multilingual_speaker_emb_train.py
@@ -94,7 +94,6 @@ def test_train(tmp_path):
     speaker_id = "ljspeech-1"
     language_id = "en"
     continue_speakers_path = continue_path / "speakers.json"
-    continue_languages_path = continue_path / "language_ids.json"
 
     # Check integrity of the config
     with continue_config_path.open() as f:
@@ -113,8 +112,6 @@ def test_train(tmp_path):
         language_id,
         "--speakers_file_path",
         str(continue_speakers_path),
-        "--language_ids_file_path",
-        str(continue_languages_path),
         "--config_path",
         str(continue_config_path),
         "--model_path",

--- a/tests/integration/test_vits_multilingual_train-d_vectors.py
+++ b/tests/integration/test_vits_multilingual_train-d_vectors.py
@@ -100,7 +100,6 @@ def test_train(tmp_path):
     speaker_id = "ljspeech-1"
     language_id = "en"
     continue_speakers_path = config.d_vector_file
-    continue_languages_path = continue_path / "language_ids.json"
 
     # Check integrity of the config
     with continue_config_path.open() as f:
@@ -119,8 +118,6 @@ def test_train(tmp_path):
         language_id,
         "--speakers_file_path",
         str(continue_speakers_path),
-        "--language_ids_file_path",
-        str(continue_languages_path),
         "--config_path",
         str(continue_config_path),
         "--model_path",

--- a/tests/text_tests/test_characters.py
+++ b/tests/text_tests/test_characters.py
@@ -53,66 +53,62 @@ class TestBaseVocabulary:
 
 
 class TestBaseCharacters:
-    @pytest.fixture
-    def characters_empty(self):
-        return BaseCharacters("", "", pad="", eos="", bos="", blank="", is_unique=True, is_sorted=True)
-
     def test_default_character_sets(self):
         """Test initiation of default character sets"""
         IPAPhonemes()
         Graphemes()
 
-    def test_unique(self, characters_empty):
+    def test_unique(self):
         """Test if the unique option works"""
-        characters_empty.characters = "abcc"
-        characters_empty.punctuations = ".,;:!? "
-        characters_empty.pad = "[PAD]"
-        characters_empty.eos = "[EOS]"
-        characters_empty.bos = "[BOS]"
-        characters_empty.blank = "[BLANK]"
-
-        assert characters_empty.num_chars == len(
-            ["[PAD]", "[EOS]", "[BOS]", "[BLANK]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
+        characters = BaseCharacters(
+            characters="bacc",
+            punctuations=".,;:!? ",
+            pad="[PAD]",
+            eos="[EOS]",
+            bos="[BOS]",
+            blank="[BLANK]",
+            is_unique=True,
         )
 
-    def test_unique_sorted(self, characters_empty):
+        assert characters.num_chars == len(
+            ["[PAD]", "[EOS]", "[BOS]", "[BLANK]", "b", "a", "c", ".", ",", ";", ":", "!", "?", " "]
+        )
+
+    def test_unique_sorted(self):
         """Test if the unique and sorted option works"""
-        characters_empty.characters = "cba"
-        characters_empty.punctuations = ".,;:!? "
-        characters_empty.pad = "[PAD]"
-        characters_empty.eos = "[EOS]"
-        characters_empty.bos = "[BOS]"
-        characters_empty.blank = "[BLANK]"
+        characters = BaseCharacters(
+            characters="ccba",
+            punctuations=".,;:!? ",
+            pad="[PAD]",
+            eos="[EOS]",
+            bos="[BOS]",
+            blank="[BLANK]",
+            is_unique=True,
+            is_sorted=True,
+        )
 
-        assert characters_empty.num_chars == len(
+        assert characters.num_chars == len(
             ["[PAD]", "[EOS]", "[BOS]", "[BLANK]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
         )
 
-    def test_setters_getters(self, characters_empty):
-        """Test the class setters behaves as expected"""
-        characters_empty.characters = "abc"
-        assert characters_empty._characters == "abc"
-        assert characters_empty.vocab == ["a", "b", "c"]
-
-        characters_empty.punctuations = ".,;:!? "
-        assert characters_empty._punctuations == ".,;:!? "
-        assert characters_empty.vocab == ["a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
-
-        characters_empty.pad = "[PAD]"
-        assert characters_empty._pad == "[PAD]"
-        assert characters_empty.vocab == ["[PAD]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
-
-        characters_empty.eos = "[EOS]"
-        assert characters_empty._eos == "[EOS]"
-        assert characters_empty.vocab == ["[PAD]", "[EOS]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
-
-        characters_empty.bos = "[BOS]"
-        assert characters_empty._bos == "[BOS]"
-        assert characters_empty.vocab == ["[PAD]", "[EOS]", "[BOS]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
-
-        characters_empty.blank = "[BLANK]"
-        assert characters_empty._blank == "[BLANK]"
-        assert characters_empty.vocab == [
+    def test_getters(self):
+        """Test the class getters behave as expected"""
+        characters = BaseCharacters(
+            characters="abc",
+            punctuations=".,;:!? ",
+            pad="[PAD]",
+            eos="[EOS]",
+            bos="[BOS]",
+            blank="[BLANK]",
+            is_unique=True,
+        )
+        assert characters.characters == "abc"
+        assert characters.punctuations == ".,;:!? "
+        assert characters.pad == "[PAD]"
+        assert characters.eos == "[EOS]"
+        assert characters.bos == "[BOS]"
+        assert characters.blank == "[BLANK]"
+        assert characters.vocab == [
             "[PAD]",
             "[EOS]",
             "[BOS]",
@@ -128,49 +124,52 @@ class TestBaseCharacters:
             "?",
             " ",
         ]
-        assert characters_empty.num_chars == len(
+        assert characters.num_chars == len(
             ["[PAD]", "[EOS]", "[BOS]", "[BLANK]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
         )
 
-        characters_empty.print_log()
+        characters.print_log()
 
-    def test_char_lookup(self, characters_empty):
+    def test_char_lookup(self):
         """Test char to ID and ID to char conversion"""
-        characters_empty.characters = "abc"
-        characters_empty.punctuations = ".,;:!? "
-        characters_empty.pad = "[PAD]"
-        characters_empty.eos = "[EOS]"
-        characters_empty.bos = "[BOS]"
-        characters_empty.blank = "[BLANK]"
+        characters = BaseCharacters(
+            characters="abc",
+            punctuations=".,;:!? ",
+            pad="[PAD]",
+            eos="[EOS]",
+            bos="[BOS]",
+            blank="[BLANK]",
+            is_unique=True,
+        )
 
         # char to ID
-        assert characters_empty.char_to_id("[PAD]") == 0
-        assert characters_empty.char_to_id("[EOS]") == 1
-        assert characters_empty.char_to_id("[BOS]") == 2
-        assert characters_empty.char_to_id("[BLANK]") == 3
-        assert characters_empty.char_to_id("a") == 4
-        assert characters_empty.char_to_id("b") == 5
-        assert characters_empty.char_to_id("c") == 6
-        assert characters_empty.char_to_id(".") == 7
-        assert characters_empty.char_to_id(",") == 8
-        assert characters_empty.char_to_id(";") == 9
-        assert characters_empty.char_to_id(":") == 10
-        assert characters_empty.char_to_id("!") == 11
-        assert characters_empty.char_to_id("?") == 12
-        assert characters_empty.char_to_id(" ") == 13
+        assert characters.char_to_id("[PAD]") == 0
+        assert characters.char_to_id("[EOS]") == 1
+        assert characters.char_to_id("[BOS]") == 2
+        assert characters.char_to_id("[BLANK]") == 3
+        assert characters.char_to_id("a") == 4
+        assert characters.char_to_id("b") == 5
+        assert characters.char_to_id("c") == 6
+        assert characters.char_to_id(".") == 7
+        assert characters.char_to_id(",") == 8
+        assert characters.char_to_id(";") == 9
+        assert characters.char_to_id(":") == 10
+        assert characters.char_to_id("!") == 11
+        assert characters.char_to_id("?") == 12
+        assert characters.char_to_id(" ") == 13
 
         # ID to char
-        assert characters_empty.id_to_char(0) == "[PAD]"
-        assert characters_empty.id_to_char(1) == "[EOS]"
-        assert characters_empty.id_to_char(2) == "[BOS]"
-        assert characters_empty.id_to_char(3) == "[BLANK]"
-        assert characters_empty.id_to_char(4) == "a"
-        assert characters_empty.id_to_char(5) == "b"
-        assert characters_empty.id_to_char(6) == "c"
-        assert characters_empty.id_to_char(7) == "."
-        assert characters_empty.id_to_char(8) == ","
-        assert characters_empty.id_to_char(9) == ";"
-        assert characters_empty.id_to_char(10) == ":"
-        assert characters_empty.id_to_char(11) == "!"
-        assert characters_empty.id_to_char(12) == "?"
-        assert characters_empty.id_to_char(13) == " "
+        assert characters.id_to_char(0) == "[PAD]"
+        assert characters.id_to_char(1) == "[EOS]"
+        assert characters.id_to_char(2) == "[BOS]"
+        assert characters.id_to_char(3) == "[BLANK]"
+        assert characters.id_to_char(4) == "a"
+        assert characters.id_to_char(5) == "b"
+        assert characters.id_to_char(6) == "c"
+        assert characters.id_to_char(7) == "."
+        assert characters.id_to_char(8) == ","
+        assert characters.id_to_char(9) == ";"
+        assert characters.id_to_char(10) == ":"
+        assert characters.id_to_char(11) == "!"
+        assert characters.id_to_char(12) == "?"
+        assert characters.id_to_char(13) == " "

--- a/tests/text_tests/test_characters.py
+++ b/tests/text_tests/test_characters.py
@@ -1,174 +1,176 @@
-import unittest
+import pytest
 
 from TTS.tts.utils.text.characters import BaseCharacters, BaseVocabulary, Graphemes, IPAPhonemes
 
-# pylint: disable=protected-access
 
+class TestBaseVocabulary:
+    @pytest.fixture
+    def phonemes(self):
+        return IPAPhonemes()
 
-class BaseVocabularyTest(unittest.TestCase):
-    def setUp(self):
-        self.phonemes = IPAPhonemes()
-        self.base_vocab = BaseVocabulary(
-            vocab=self.phonemes._vocab,
-            pad=self.phonemes.pad,
-            blank=self.phonemes.blank,
-            bos=self.phonemes.bos,
-            eos=self.phonemes.eos,
+    @pytest.fixture
+    def base_vocab(self, phonemes):
+        return BaseVocabulary(
+            vocab=phonemes._vocab,
+            pad=phonemes.pad,
+            blank=phonemes.blank,
+            bos=phonemes.bos,
+            eos=phonemes.eos,
         )
-        self.empty_vocab = BaseVocabulary({})
 
-    def test_pad_id(self):
-        self.assertEqual(self.empty_vocab.pad_id, 0)
-        self.assertEqual(self.base_vocab.pad_id, self.phonemes.pad_id)
+    @pytest.fixture
+    def empty_vocab(self):
+        return BaseVocabulary({})
 
-    def test_blank_id(self):
-        self.assertEqual(self.empty_vocab.blank_id, 0)
-        self.assertEqual(self.base_vocab.blank_id, self.phonemes.blank_id)
+    def test_pad_id(self, empty_vocab, base_vocab, phonemes):
+        assert empty_vocab.pad_id == 0
+        assert base_vocab.pad_id == phonemes.pad_id
 
-    def test_vocab(self):
-        self.assertEqual(self.empty_vocab.vocab, {})
-        self.assertEqual(self.base_vocab.vocab, self.phonemes._vocab)
+    def test_blank_id(self, empty_vocab, base_vocab, phonemes):
+        assert empty_vocab.blank_id == 0
+        assert base_vocab.blank_id == phonemes.blank_id
 
-    # def test_init_from_config(self):
-    #     ...
+    def test_vocab(self, empty_vocab, base_vocab, phonemes):
+        assert empty_vocab.vocab == {}
+        assert base_vocab.vocab == phonemes._vocab
 
-    def test_num_chars(self):
-        self.assertEqual(self.empty_vocab.num_chars, 0)
-        self.assertEqual(self.base_vocab.num_chars, self.phonemes.num_chars)
+    def test_num_chars(self, empty_vocab, base_vocab, phonemes):
+        assert empty_vocab.num_chars == 0
+        assert base_vocab.num_chars == phonemes.num_chars
 
-    def test_char_to_id(self):
-        try:
-            self.empty_vocab.char_to_id("a")
-            raise Exception("Should have raised KeyError")
-        except:
-            pass
-        for k in self.phonemes.vocab:
-            self.assertEqual(self.base_vocab.char_to_id(k), self.phonemes.char_to_id(k))
+    def test_char_to_id(self, empty_vocab, base_vocab, phonemes):
+        with pytest.raises(KeyError):
+            empty_vocab.char_to_id("a")
+        for k in phonemes.vocab:
+            assert base_vocab.char_to_id(k) == phonemes.char_to_id(k)
 
-    def test_id_to_char(self):
-        try:
-            self.empty_vocab.id_to_char(0)
-            raise Exception("Should have raised KeyError")
-        except:
-            pass
-        for k in self.phonemes.vocab:
-            v = self.phonemes.char_to_id(k)
-            self.assertEqual(self.base_vocab.id_to_char(v), self.phonemes.id_to_char(v))
+    def test_id_to_char(self, empty_vocab, base_vocab, phonemes):
+        with pytest.raises(KeyError):
+            empty_vocab.id_to_char(0)
+        for k in phonemes.vocab:
+            v = phonemes.char_to_id(k)
+            assert base_vocab.id_to_char(v) == phonemes.id_to_char(v)
 
 
-class BaseCharacterTest(unittest.TestCase):
-    def setUp(self):
-        self.characters_empty = BaseCharacters("", "", pad="", eos="", bos="", blank="", is_unique=True, is_sorted=True)
+class TestBaseCharacters:
+    @pytest.fixture
+    def characters_empty(self):
+        return BaseCharacters("", "", pad="", eos="", bos="", blank="", is_unique=True, is_sorted=True)
 
-    def test_default_character_sets(self):  # pylint: disable=no-self-use
+    def test_default_character_sets(self):
         """Test initiation of default character sets"""
-        _ = IPAPhonemes()
-        _ = Graphemes()
+        IPAPhonemes()
+        Graphemes()
 
-    def test_unique(self):
+    def test_unique(self, characters_empty):
         """Test if the unique option works"""
-        self.characters_empty.characters = "abcc"
-        self.characters_empty.punctuations = ".,;:!? "
-        self.characters_empty.pad = "[PAD]"
-        self.characters_empty.eos = "[EOS]"
-        self.characters_empty.bos = "[BOS]"
-        self.characters_empty.blank = "[BLANK]"
+        characters_empty.characters = "abcc"
+        characters_empty.punctuations = ".,;:!? "
+        characters_empty.pad = "[PAD]"
+        characters_empty.eos = "[EOS]"
+        characters_empty.bos = "[BOS]"
+        characters_empty.blank = "[BLANK]"
 
-        self.assertEqual(
-            self.characters_empty.num_chars,
-            len(["[PAD]", "[EOS]", "[BOS]", "[BLANK]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]),
+        assert characters_empty.num_chars == len(
+            ["[PAD]", "[EOS]", "[BOS]", "[BLANK]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
         )
 
-    def test_unique_sorted(self):
+    def test_unique_sorted(self, characters_empty):
         """Test if the unique and sorted option works"""
-        self.characters_empty.characters = "cba"
-        self.characters_empty.punctuations = ".,;:!? "
-        self.characters_empty.pad = "[PAD]"
-        self.characters_empty.eos = "[EOS]"
-        self.characters_empty.bos = "[BOS]"
-        self.characters_empty.blank = "[BLANK]"
+        characters_empty.characters = "cba"
+        characters_empty.punctuations = ".,;:!? "
+        characters_empty.pad = "[PAD]"
+        characters_empty.eos = "[EOS]"
+        characters_empty.bos = "[BOS]"
+        characters_empty.blank = "[BLANK]"
 
-        self.assertEqual(
-            self.characters_empty.num_chars,
-            len(["[PAD]", "[EOS]", "[BOS]", "[BLANK]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]),
+        assert characters_empty.num_chars == len(
+            ["[PAD]", "[EOS]", "[BOS]", "[BLANK]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
         )
 
-    def test_setters_getters(self):
+    def test_setters_getters(self, characters_empty):
         """Test the class setters behaves as expected"""
-        self.characters_empty.characters = "abc"
-        self.assertEqual(self.characters_empty._characters, "abc")
-        self.assertEqual(self.characters_empty.vocab, ["a", "b", "c"])
+        characters_empty.characters = "abc"
+        assert characters_empty._characters == "abc"
+        assert characters_empty.vocab == ["a", "b", "c"]
 
-        self.characters_empty.punctuations = ".,;:!? "
-        self.assertEqual(self.characters_empty._punctuations, ".,;:!? ")
-        self.assertEqual(self.characters_empty.vocab, ["a", "b", "c", ".", ",", ";", ":", "!", "?", " "])
+        characters_empty.punctuations = ".,;:!? "
+        assert characters_empty._punctuations == ".,;:!? "
+        assert characters_empty.vocab == ["a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
 
-        self.characters_empty.pad = "[PAD]"
-        self.assertEqual(self.characters_empty._pad, "[PAD]")
-        self.assertEqual(self.characters_empty.vocab, ["[PAD]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "])
+        characters_empty.pad = "[PAD]"
+        assert characters_empty._pad == "[PAD]"
+        assert characters_empty.vocab == ["[PAD]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
 
-        self.characters_empty.eos = "[EOS]"
-        self.assertEqual(self.characters_empty._eos, "[EOS]")
-        self.assertEqual(
-            self.characters_empty.vocab, ["[PAD]", "[EOS]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
+        characters_empty.eos = "[EOS]"
+        assert characters_empty._eos == "[EOS]"
+        assert characters_empty.vocab == ["[PAD]", "[EOS]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
+
+        characters_empty.bos = "[BOS]"
+        assert characters_empty._bos == "[BOS]"
+        assert characters_empty.vocab == ["[PAD]", "[EOS]", "[BOS]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
+
+        characters_empty.blank = "[BLANK]"
+        assert characters_empty._blank == "[BLANK]"
+        assert characters_empty.vocab == [
+            "[PAD]",
+            "[EOS]",
+            "[BOS]",
+            "[BLANK]",
+            "a",
+            "b",
+            "c",
+            ".",
+            ",",
+            ";",
+            ":",
+            "!",
+            "?",
+            " ",
+        ]
+        assert characters_empty.num_chars == len(
+            ["[PAD]", "[EOS]", "[BOS]", "[BLANK]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
         )
 
-        self.characters_empty.bos = "[BOS]"
-        self.assertEqual(self.characters_empty._bos, "[BOS]")
-        self.assertEqual(
-            self.characters_empty.vocab, ["[PAD]", "[EOS]", "[BOS]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]
-        )
+        characters_empty.print_log()
 
-        self.characters_empty.blank = "[BLANK]"
-        self.assertEqual(self.characters_empty._blank, "[BLANK]")
-        self.assertEqual(
-            self.characters_empty.vocab,
-            ["[PAD]", "[EOS]", "[BOS]", "[BLANK]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "],
-        )
-        self.assertEqual(
-            self.characters_empty.num_chars,
-            len(["[PAD]", "[EOS]", "[BOS]", "[BLANK]", "a", "b", "c", ".", ",", ";", ":", "!", "?", " "]),
-        )
-
-        self.characters_empty.print_log()
-
-    def test_char_lookup(self):
+    def test_char_lookup(self, characters_empty):
         """Test char to ID and ID to char conversion"""
-        self.characters_empty.characters = "abc"
-        self.characters_empty.punctuations = ".,;:!? "
-        self.characters_empty.pad = "[PAD]"
-        self.characters_empty.eos = "[EOS]"
-        self.characters_empty.bos = "[BOS]"
-        self.characters_empty.blank = "[BLANK]"
+        characters_empty.characters = "abc"
+        characters_empty.punctuations = ".,;:!? "
+        characters_empty.pad = "[PAD]"
+        characters_empty.eos = "[EOS]"
+        characters_empty.bos = "[BOS]"
+        characters_empty.blank = "[BLANK]"
 
         # char to ID
-        self.assertEqual(self.characters_empty.char_to_id("[PAD]"), 0)
-        self.assertEqual(self.characters_empty.char_to_id("[EOS]"), 1)
-        self.assertEqual(self.characters_empty.char_to_id("[BOS]"), 2)
-        self.assertEqual(self.characters_empty.char_to_id("[BLANK]"), 3)
-        self.assertEqual(self.characters_empty.char_to_id("a"), 4)
-        self.assertEqual(self.characters_empty.char_to_id("b"), 5)
-        self.assertEqual(self.characters_empty.char_to_id("c"), 6)
-        self.assertEqual(self.characters_empty.char_to_id("."), 7)
-        self.assertEqual(self.characters_empty.char_to_id(","), 8)
-        self.assertEqual(self.characters_empty.char_to_id(";"), 9)
-        self.assertEqual(self.characters_empty.char_to_id(":"), 10)
-        self.assertEqual(self.characters_empty.char_to_id("!"), 11)
-        self.assertEqual(self.characters_empty.char_to_id("?"), 12)
-        self.assertEqual(self.characters_empty.char_to_id(" "), 13)
+        assert characters_empty.char_to_id("[PAD]") == 0
+        assert characters_empty.char_to_id("[EOS]") == 1
+        assert characters_empty.char_to_id("[BOS]") == 2
+        assert characters_empty.char_to_id("[BLANK]") == 3
+        assert characters_empty.char_to_id("a") == 4
+        assert characters_empty.char_to_id("b") == 5
+        assert characters_empty.char_to_id("c") == 6
+        assert characters_empty.char_to_id(".") == 7
+        assert characters_empty.char_to_id(",") == 8
+        assert characters_empty.char_to_id(";") == 9
+        assert characters_empty.char_to_id(":") == 10
+        assert characters_empty.char_to_id("!") == 11
+        assert characters_empty.char_to_id("?") == 12
+        assert characters_empty.char_to_id(" ") == 13
 
         # ID to char
-        self.assertEqual(self.characters_empty.id_to_char(0), "[PAD]")
-        self.assertEqual(self.characters_empty.id_to_char(1), "[EOS]")
-        self.assertEqual(self.characters_empty.id_to_char(2), "[BOS]")
-        self.assertEqual(self.characters_empty.id_to_char(3), "[BLANK]")
-        self.assertEqual(self.characters_empty.id_to_char(4), "a")
-        self.assertEqual(self.characters_empty.id_to_char(5), "b")
-        self.assertEqual(self.characters_empty.id_to_char(6), "c")
-        self.assertEqual(self.characters_empty.id_to_char(7), ".")
-        self.assertEqual(self.characters_empty.id_to_char(8), ",")
-        self.assertEqual(self.characters_empty.id_to_char(9), ";")
-        self.assertEqual(self.characters_empty.id_to_char(10), ":")
-        self.assertEqual(self.characters_empty.id_to_char(11), "!")
-        self.assertEqual(self.characters_empty.id_to_char(12), "?")
-        self.assertEqual(self.characters_empty.id_to_char(13), " ")
+        assert characters_empty.id_to_char(0) == "[PAD]"
+        assert characters_empty.id_to_char(1) == "[EOS]"
+        assert characters_empty.id_to_char(2) == "[BOS]"
+        assert characters_empty.id_to_char(3) == "[BLANK]"
+        assert characters_empty.id_to_char(4) == "a"
+        assert characters_empty.id_to_char(5) == "b"
+        assert characters_empty.id_to_char(6) == "c"
+        assert characters_empty.id_to_char(7) == "."
+        assert characters_empty.id_to_char(8) == ","
+        assert characters_empty.id_to_char(9) == ";"
+        assert characters_empty.id_to_char(10) == ":"
+        assert characters_empty.id_to_char(11) == "!"
+        assert characters_empty.id_to_char(12) == "?"
+        assert characters_empty.id_to_char(13) == " "

--- a/tests/text_tests/test_phonemizer.py
+++ b/tests/text_tests/test_phonemizer.py
@@ -3,10 +3,12 @@ import unittest
 import pytest
 from packaging.version import Version
 
-from TTS.tts.utils.text.phonemizers import ESpeak, Gruut, JA_JP_Phonemizer, ZH_CN_Phonemizer
 from TTS.tts.utils.text.phonemizers.bangla_phonemizer import BN_Phonemizer
-from TTS.tts.utils.text.phonemizers.espeak_wrapper import _is_tool
+from TTS.tts.utils.text.phonemizers.espeak_wrapper import ESpeak, _is_tool
+from TTS.tts.utils.text.phonemizers.gruut_wrapper import Gruut
+from TTS.tts.utils.text.phonemizers.ja_jp_phonemizer import JA_JP_Phonemizer
 from TTS.tts.utils.text.phonemizers.multi_phonemizer import MultiPhonemizer
+from TTS.tts.utils.text.phonemizers.zh_cn_phonemizer import ZH_CN_Phonemizer
 
 EXAMPLE_TEXTs = [
     "Recent research at Harvard has shown meditating",
@@ -295,11 +297,8 @@ class TestMultiPhonemizer(unittest.TestCase):
             MultiPhonemizer({"tr": "espeak", "fr": "xx"})
 
     def test_sub_phonemizers(self):
-        for lang in self.phonemizer.lang_to_phonemizer_name.keys():
+        for lang in self.phonemizer.lang_to_phonemizer.keys():
             self.assertEqual(lang, self.phonemizer.lang_to_phonemizer[lang].language)
-            self.assertEqual(
-                self.phonemizer.lang_to_phonemizer_name[lang], self.phonemizer.lang_to_phonemizer[lang].name()
-            )
 
     def test_name(self):
         self.assertEqual(self.phonemizer.name(), "multi-phonemizer")

--- a/tests/zoo_tests/test_big_models.py
+++ b/tests/zoo_tests/test_big_models.py
@@ -12,9 +12,9 @@ from TTS.utils.manage import ModelManager
 GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 
-@pytest.fixture(scope="session", autouse=True)
-def set_env():
-    os.environ["COQUI_TOS_AGREED"] = "1"
+@pytest.fixture(autouse=True)
+def set_env(monkeypatch):
+    monkeypatch.setenv("COQUI_TOS_AGREED", "1")
 
 
 @pytest.fixture
@@ -53,11 +53,11 @@ def test_xtts_streaming(manager, device: torch.device):
     speaker_wav = [os.path.join(get_tests_data_path(), "ljspeech", "wavs", "LJ001-0001.wav")]
     speaker_wav_2 = os.path.join(get_tests_data_path(), "ljspeech", "wavs", "LJ001-0002.wav")
     speaker_wav.append(speaker_wav_2)
-    model_path, _, _ = manager.download_model("tts_models/multilingual/multi-dataset/xtts_v1.1")
+    model_path, config_path, _ = manager.download_model("tts_models/multilingual/multi-dataset/xtts_v1.1")
     config = XttsConfig()
-    config.load_json(model_path / "config.json")
+    config.load_json(config_path)
     model = Xtts.init_from_config(config)
-    model.load_checkpoint(config, checkpoint_dir=str(model_path))
+    model.load_checkpoint(config, checkpoint_dir=str(model_path.parent))
     model.to(device)
 
     print("Computing speaker latents...")
@@ -107,11 +107,11 @@ def test_xtts_v2_streaming(manager, device: torch.device):
     from TTS.tts.models.xtts import Xtts
 
     speaker_wav = [os.path.join(get_tests_data_path(), "ljspeech", "wavs", "LJ001-0001.wav")]
-    model_path, _, _ = manager.download_model("tts_models/multilingual/multi-dataset/xtts_v2")
+    model_path, config_path, _ = manager.download_model("tts_models/multilingual/multi-dataset/xtts_v2")
     config = XttsConfig()
-    config.load_json(model_path / "config.json")
+    config.load_json(config_path)
     model = Xtts.init_from_config(config)
-    model.load_checkpoint(config, checkpoint_dir=str(model_path))
+    model.load_checkpoint(config, checkpoint_dir=str(model_path.parent))
     model.to(device)
 
     print("Computing speaker latents...")


### PR DESCRIPTION
Improve import/startup time by late-importing/lazy-loading modules where possible:
```bash
hyperfine --warmup 1 --runs 10 'uv run python -c "from TTS.api import TTS"'
```
- v0.27.0: `19.720 s ±  0.869 s`
- This PR: `4.361 s ±  0.074 s` (with all extras installed)

Also remove that `language_ids_file_path` argument from APIs and ensure that Pytorch is installed in Docker images since it's not included by default anymore (see #546, fixes #563).