### PR TITLE
fix(vits): update onnx opset version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,7 @@ jobs:
           sudo apt-get install espeak espeak-ng
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends git make gcc
           make system-deps
       - name: Install custom Trainer and/or Coqpit if requested
@@ -107,6 +108,7 @@ jobs:
           sudo apt-get install espeak espeak-ng
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends git make gcc
           make system-deps
       - name: Install custom Trainer and/or Coqpit if requested
@@ -150,6 +152,7 @@ jobs:
           sudo apt-get install espeak espeak-ng
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends git make gcc
           make system-deps
       - name: Install custom Trainer and/or Coqpit if requested
@@ -187,6 +190,7 @@ jobs:
           sudo apt-get install espeak espeak-ng
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends git make gcc
           make system-deps
       - name: Install custom Trainer and/or Coqpit if requested

--- a/TTS/tts/models/vits.py
+++ b/TTS/tts/models/vits.py
@@ -1322,7 +1322,7 @@ class Vits(BaseTTS):
         torch.onnx.export(
             model=self,
             args=dummy_input,
-            opset_version=15,
+            opset_version=18,
             f=output_path,
             verbose=verbose,
             input_names=input_names,
@@ -1332,6 +1332,7 @@ class Vits(BaseTTS):
                 "input_lengths": {0: "batch_size"},
                 "output": {0: "batch_size", 1: "time1", 2: "time2"},
             },
+            dynamo=False,
         )
 
         # rollback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "pyyaml>=6.0",
     "fsspec[http]>=2023.6.0",
     "packaging>=23.1",
-    "typing_extensions>=4.10",
+    "typing_extensions>=4.13",
     # Inference
     "pysbd>=0.3.4",
     # Training


### PR DESCRIPTION
Changed: opset_version from 15 to 18
added: dynamo=False for newer versions of torch.export.onnx function On branch export-onnx-fix
Changes to be committed:
	modified:   TTS/tts/models/vits.py