### PR TITLE
Reject unsupported model types in TTS API and server with clear errors

### DIFF
--- a/TTS/api.py
+++ b/TTS/api.py
@@ -92,6 +92,15 @@ class TTS(nn.Module):
             warnings.warn("`gpu` will be deprecated. Please use `tts.to(device)` instead.")
 
         if model_name is not None and len(model_name) > 0:
+            if "vocoder_models" in model_name:
+                msg = (
+                    f"Vocoder model '{model_name}' cannot be used as a standalone model. "
+                    "Vocoder models can only be used together with a TTS model via the "
+                    "`vocoder_name` parameter, e.g.:\n"
+                    '  TTS(model_name="tts_models/de/thorsten/tacotron2-DDC", '
+                    f'vocoder_name="{model_name}")'
+                )
+                raise ValueError(msg)
             self.voice_dir = get_user_data_dir("tts") / model_name / "voices"
             if "tts_models" in model_name:
                 self.load_tts_model_by_name(model_name, vocoder_name, gpu=gpu)

--- a/TTS/server/server.py
+++ b/TTS/server/server.py
@@ -106,6 +106,15 @@ api = TTS(
     speakers_file_path=args.speakers_file_path,
 ).to(device)
 
+if api.synthesizer is None:
+    logger.error(
+        "The tts-server requires a TTS model but '%s' did not initialize one. "
+        "Voice conversion and vocoder models are not supported by the server. "
+        "Please use a TTS model, e.g.: tts-server --model_name tts_models/en/ljspeech/tacotron2-DDC",
+        model_name or args.model_path,
+    )
+    sys.exit(1)
+
 # TODO: set this from SpeakerManager
 use_gst = api.synthesizer.tts_config.get("use_gst", False)
 

--- a/TTS/server/server.py
+++ b/TTS/server/server.py
@@ -106,7 +106,7 @@ api = TTS(
     speakers_file_path=args.speakers_file_path,
 ).to(device)
 
-if api.synthesizer is None:
+if getattr(api.synthesizer, "tts_model", None) is None:
     logger.error(
         "The tts-server requires a TTS model but '%s' did not initialize one. "
         "Voice conversion and vocoder models are not supported by the server. "

--- a/tests/aux_tests/test_api.py
+++ b/tests/aux_tests/test_api.py
@@ -7,9 +7,3 @@ def test_vocoder_model_name_rejected():
     """Passing a vocoder model name as model_name should raise a clear error."""
     with pytest.raises(ValueError, match="cannot be used as a standalone model"):
         TTS(model_name="vocoder_models/de/thorsten/wavegrad")
-
-
-def test_vocoder_model_name_error_suggests_vocoder_name():
-    """The error message should suggest using vocoder_name instead."""
-    with pytest.raises(ValueError, match="vocoder_name"):
-        TTS(model_name="vocoder_models/en/ljspeech/multiband-melgan")

--- a/tests/aux_tests/test_api_validation.py
+++ b/tests/aux_tests/test_api_validation.py
@@ -1,0 +1,15 @@
+import pytest
+
+from TTS.api import TTS
+
+
+def test_vocoder_model_name_rejected():
+    """Passing a vocoder model name as model_name should raise a clear error."""
+    with pytest.raises(ValueError, match="cannot be used as a standalone model"):
+        TTS(model_name="vocoder_models/de/thorsten/wavegrad")
+
+
+def test_vocoder_model_name_error_suggests_vocoder_name():
+    """The error message should suggest using vocoder_name instead."""
+    with pytest.raises(ValueError, match="vocoder_name"):
+        TTS(model_name="vocoder_models/en/ljspeech/multiband-melgan")


### PR DESCRIPTION
Passing a vocoder-only model (e.g. vocoder_models/de/thorsten/wavegrad) as model_name to the TTS API would fall through to load_model_by_name() and crash deep in Synthesizer with an opaque KeyError: 'use_phonemes'. Similarly, passing a voice conversion model to the tts-server would set voice_converter but leave synthesizer as None, crashing on api.synthesizer.tts_config access.

Add early validation in TTS.__init__() to reject vocoder model names with a helpful error message suggesting the vocoder_name parameter instead. Add a guard in the server to exit gracefully when no TTS synthesizer is initialized, with a clear message about supported model types.

Related: #562