### PR TITLE
Add optional OmniVoice integration

### DIFF
--- a/TTS/.models.json
+++ b/TTS/.models.json
@@ -19,6 +19,13 @@
                     "contact": "info@coqui.ai",
                     "tos_required": true
                 },
+                "omnivoice": {
+                    "description": "OmniVoice, an omnilingual zero-shot TTS model by k2-fsa with voice cloning and voice design.",
+                    "repo_id": "k2-fsa/OmniVoice",
+                    "default_vocoder": null,
+                    "license": "CC-BY-NC",
+                    "contact": "https://github.com/k2-fsa/OmniVoice"
+                },
                 "your_tts": {
                     "description": "Your TTS model accompanying the paper https://arxiv.org/abs/2112.02418",
                     "github_rls_url": "https://github.com/coqui-ai/TTS/releases/download/v0.10.1_models/tts_models--multilingual--multi-dataset--your_tts.zip",

--- a/TTS/config/__init__.py
+++ b/TTS/config/__init__.py
@@ -66,7 +66,13 @@ def _process_model_name(config_dict: dict) -> str:
     Returns:
         str: Formatted modelname.
     """
-    model_name = config_dict["model"] if "model" in config_dict else config_dict["generator_model"]
+    if "model" in config_dict:
+        model_name = config_dict["model"]
+    elif "generator_model" in config_dict:
+        model_name = config_dict["generator_model"]
+    else:
+        # Hugging Face Transformers configurations use `model_type`.
+        model_name = config_dict["model_type"]
     model_name = model_name.replace("_generator", "").replace("_discriminator", "")
     return model_name
 

--- a/TTS/tts/configs/omnivoice_config.py
+++ b/TTS/tts/configs/omnivoice_config.py
@@ -1,0 +1,24 @@
+"""Configuration for the optional OmniVoice integration."""
+
+from dataclasses import dataclass, field
+
+from coqpit import Coqpit
+
+from TTS.tts.configs.shared_configs import BaseTTSConfig
+
+
+@dataclass
+class OmnivoiceAudioConfig(Coqpit):
+    sample_rate: int = 24000
+    output_sample_rate: int = 24000
+
+
+@dataclass
+class OmnivoiceConfig(BaseTTSConfig):
+    """Coqui configuration adapter for a Hugging Face OmniVoice checkpoint."""
+
+    model: str = "omnivoice"
+    _supports_cloning: bool = True
+    # Replaced with OmniVoice's complete language list after loading the checkpoint.
+    languages: list[str] = field(default_factory=lambda: ["en"])
+    audio: OmnivoiceAudioConfig = field(default_factory=OmnivoiceAudioConfig)

--- a/TTS/tts/models/omnivoice.py
+++ b/TTS/tts/models/omnivoice.py
@@ -1,0 +1,136 @@
+"""Thin Coqui TTS adapter for the optional OmniVoice package."""
+
+import os
+from typing import Any
+
+import torch
+from coqpit import Coqpit
+
+from TTS.tts.models.base_tts import BaseTTS
+from TTS.utils.generic_utils import warn_synthesize_config_deprecated, warn_synthesize_speaker_id_deprecated
+
+
+class Omnivoice(BaseTTS):
+    """Expose k2-fsa OmniVoice through Coqui's synthesis and voice-caching APIs."""
+
+    def __init__(self, config: Coqpit) -> None:
+        self.tokenizer = None  # OmniVoice provides its own tokenizer.
+        super().__init__(config)
+        self.model = None
+
+    def load_checkpoint(
+        self,
+        config: Coqpit,
+        checkpoint_dir: str | os.PathLike[Any],
+        *,
+        eval: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        try:
+            from omnivoice import OmniVoice as OmniVoiceModel
+        except ImportError as e:
+            raise ImportError(
+                "OmniVoice support requires its optional dependency: pip install 'coqui-tts[omnivoice]'"
+            ) from e
+
+        self.model = OmniVoiceModel.from_pretrained(str(checkpoint_dir), dtype=torch.float32)
+        self.config.audio.sample_rate = self.model.sampling_rate
+        self.config.audio.output_sample_rate = self.model.sampling_rate
+        languages = sorted(self.model.supported_language_ids())
+        self.language_manager.name_to_id = {language: index for index, language in enumerate(languages)}
+        self.config.languages = languages
+        if eval:
+            self.eval()
+
+    def _require_model(self):
+        if self.model is None:
+            raise RuntimeError("OmniVoice checkpoint has not been loaded.")
+        return self.model
+
+    def _apply(self, fn, recurse=True):
+        """Move the generator while keeping the large audio tokenizer on CPU.
+
+        OmniVoice requires this on Apple Silicon because its tokenizer has an
+        output channel count unsupported by MPS. It is also a lower-memory
+        default on CUDA devices.
+        """
+        audio_tokenizer = getattr(self.model, "audio_tokenizer", None)
+        if audio_tokenizer is not None:
+            self.model.audio_tokenizer = None
+        try:
+            return super()._apply(fn, recurse=recurse)
+        finally:
+            if audio_tokenizer is not None:
+                self.model.audio_tokenizer = audio_tokenizer
+
+    def _clone_voice(
+        self,
+        speaker_wav: str | os.PathLike[Any] | list[str | os.PathLike[Any]],
+        **generate_kwargs: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        model = self._require_model()
+        if isinstance(speaker_wav, list):
+            if len(speaker_wav) != 1:
+                raise ValueError("OmniVoice accepts exactly one reference audio file.")
+            speaker_wav = speaker_wav[0]
+        prompt = model.create_voice_clone_prompt(
+            str(speaker_wav),
+            ref_text=generate_kwargs.get("ref_text"),
+            preprocess_prompt=generate_kwargs.get("preprocess_prompt", True),
+        )
+        voice = {
+            "ref_audio_tokens": prompt.ref_audio_tokens,
+            "ref_text": prompt.ref_text,
+            "ref_rms": prompt.ref_rms,
+        }
+        return voice, {"name": self.config.model}
+
+    def synthesize(
+        self,
+        text: str,
+        config: Coqpit | None = None,
+        *,
+        speaker: str | None = None,
+        speaker_wav: str | os.PathLike[Any] | list[str | os.PathLike[Any]] | None = None,
+        voice_dir: str | os.PathLike[Any] | None = None,
+        language: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if config is not None:
+            warn_synthesize_config_deprecated()
+        if (speaker_id := kwargs.pop("speaker_id", None)) is not None:
+            speaker = speaker_id
+            warn_synthesize_speaker_id_deprecated()
+
+        model = self._require_model()
+        for key in ("use_griffin_lim", "do_trim_silence", "extra_aux_input"):
+            kwargs.pop(key, None)
+
+        voice_clone_prompt = None
+        if speaker_wav is not None or speaker is not None:
+            from omnivoice.models.omnivoice import VoiceClonePrompt
+
+            voice = self.clone_voice(
+                speaker_wav,
+                speaker,
+                voice_dir,
+                ref_text=kwargs.pop("ref_text", None),
+                preprocess_prompt=kwargs.get("preprocess_prompt", True),
+            )
+            voice_clone_prompt = VoiceClonePrompt(
+                ref_audio_tokens=voice["ref_audio_tokens"],
+                ref_text=voice["ref_text"],
+                ref_rms=voice["ref_rms"],
+            )
+
+        audio = model.generate(
+            text=text,
+            language=language,
+            voice_clone_prompt=voice_clone_prompt,
+            **kwargs,
+        )[0]
+        return {"wav": audio, "text_inputs": text}
+
+    def forward(self): ...
+
+    def inference(self, input: torch.Tensor, aux_input: dict[str, Any] = {}) -> dict[str, Any]: ...

--- a/TTS/utils/manage.py
+++ b/TTS/utils/manage.py
@@ -353,7 +353,7 @@ class ModelManager:
         # find downloaded files
         output_model_path = output_path
         output_config_path = output_model_path / "config.json"
-        if model not in ["tortoise-v2", "bark", "knnvc"]:
+        if model not in ["tortoise-v2", "bark", "knnvc", "omnivoice"]:
             output_model_path, output_config_path = self._find_files(output_path)
         if model == "knnvc" and not output_config_path.exists():
             knnvc_config = KNNVCConfig()

--- a/docs/source/inference.md
+++ b/docs/source/inference.md
@@ -13,6 +13,43 @@ Coqui TTS provides three main methods for inference:
 :start-after: <!-- start inference -->
 ```
 
+## OmniVoice
+
+Install the optional integration and load OmniVoice through the regular Coqui API:
+
+```bash
+pip install "coqui-tts[omnivoice]"
+```
+
+```python
+from TTS.api import TTS
+
+tts = TTS("tts_models/multilingual/multi-dataset/omnivoice").to("cuda")
+
+# Let OmniVoice select a voice automatically.
+tts.tts_to_file("Hello from OmniVoice.", language="en", file_path="output.wav")
+
+# Clone a voice. Supplying the transcript avoids loading an ASR model.
+tts.tts_to_file(
+    "This uses a cloned voice.",
+    language="en",
+    speaker_wav="reference.wav",
+    ref_text="Transcript of the reference audio.",
+    file_path="cloned.wav",
+)
+
+# Design a voice with a natural-language instruction.
+tts.tts_to_file(
+    "This uses a designed voice.",
+    language="en",
+    instruct="male, british accent",
+    file_path="designed.wav",
+)
+```
+
+OmniVoice's code is Apache-2.0 licensed. Its pretrained weights are CC-BY-NC;
+review those noncommercial terms before downloading or using the catalogue model.
+
 
 ```{toctree}
 :hidden:

--- a/docs/source/inference.md
+++ b/docs/source/inference.md
@@ -26,8 +26,14 @@ from TTS.api import TTS
 
 tts = TTS("tts_models/multilingual/multi-dataset/omnivoice").to("cuda")
 
-# Let OmniVoice select a voice automatically.
+# OmniVoice reports its complete language list at runtime (currently 646 IDs).
+print(len(tts.languages))
+print(tts.languages)
+
+# Let OmniVoice select a voice automatically in different languages.
 tts.tts_to_file("Hello from OmniVoice.", language="en", file_path="output.wav")
+tts.tts_to_file("Xin chào từ OmniVoice.", language="vi", file_path="output-vi.wav")
+tts.tts_to_file("Hola desde OmniVoice.", language="es", file_path="output-es.wav")
 
 # Clone a voice. Supplying the transcript avoids loading an ASR model.
 tts.tts_to_file(
@@ -46,6 +52,11 @@ tts.tts_to_file(
     file_path="designed.wav",
 )
 ```
+
+The `language` argument selects one of the language IDs returned by
+`tts.languages`; `en` is used for the cloning and voice-design examples only
+because their example text is English. The integration does not hard-code an
+English-only language list.
 
 OmniVoice's code is Apache-2.0 licensed. Its pretrained weights are CC-BY-NC;
 review those noncommercial terms before downloading or using the catalogue model.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ notebooks = [
 ]
 # For running the TTS server
 server = ["flask>=3.0.0"]
+omnivoice = ["omnivoice>=0.2.1"]
 # Language-specific dependencies, mainly for G2P
 # Bangla
 bn = [

--- a/tests/tts_tests/test_omnivoice.py
+++ b/tests/tts_tests/test_omnivoice.py
@@ -1,0 +1,56 @@
+import json
+import sys
+from types import ModuleType
+
+import numpy as np
+import torch
+
+from TTS.config import load_config
+from TTS.tts.configs.omnivoice_config import OmnivoiceConfig
+from TTS.tts.models.omnivoice import Omnivoice
+
+
+class _FakeOmniVoiceModel(torch.nn.Module):
+    sampling_rate = 24000
+
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.zeros(1))
+
+    @classmethod
+    def from_pretrained(cls, path, **kwargs):
+        assert path == "/model"
+        assert kwargs["dtype"] == torch.float32
+        return cls()
+
+    @staticmethod
+    def supported_language_ids():
+        # The adapter must not restrict OmniVoice to its example languages.
+        return {"vi", "en", "aae", "yue"}
+
+    @staticmethod
+    def generate(**kwargs):
+        assert kwargs["text"] == "Hello"
+        assert kwargs["language"] == "en"
+        return [np.zeros(240, dtype=np.float32)]
+
+
+def test_load_transformers_config(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"model_type": "omnivoice", "architectures": ["OmniVoice"]}))
+    config = load_config(config_path)
+    assert isinstance(config, OmnivoiceConfig)
+
+
+def test_load_and_synthesize_without_optional_dependency(monkeypatch):
+    module = ModuleType("omnivoice")
+    module.OmniVoice = _FakeOmniVoiceModel
+    monkeypatch.setitem(sys.modules, "omnivoice", module)
+
+    model = Omnivoice(OmnivoiceConfig())
+    model.load_checkpoint(model.config, "/model", eval=True)
+    result = model.synthesize("Hello", language="en")
+
+    assert result["wav"].shape == (240,)
+    assert model.language_manager.language_names == ["aae", "en", "vi", "yue"]
+    assert model.config.languages == ["aae", "en", "vi", "yue"]

--- a/tests/zoo_tests/test_big_models.py
+++ b/tests/zoo_tests/test_big_models.py
@@ -101,6 +101,25 @@ def test_xtts_v2(tmp_path):
 
 
 @pytest.mark.skipif(GITHUB_ACTIONS, reason="Model too big for CI")
+def test_omnivoice(tmp_path):
+    """OmniVoice is too big to run on GitHub Actions."""
+    args = [
+        "--model_name",
+        "tts_models/multilingual/multi-dataset/omnivoice",
+        "--text",
+        "This is an example.",
+        "--language_idx",
+        "en",
+        "--out_path",
+        str(tmp_path / "output.wav"),
+        "--no-progress_bar",
+    ]
+    if torch.cuda.is_available():
+        args.append("--use_cuda")
+    run_main(main, args)
+
+
+@pytest.mark.skipif(GITHUB_ACTIONS, reason="Model too big for CI")
 def test_xtts_v2_streaming(manager, device: torch.device):
     """Testing the new inference_stream method"""
     from TTS.tts.configs.xtts_config import XttsConfig

--- a/tests/zoo_tests/test_models.py
+++ b/tests/zoo_tests/test_models.py
@@ -15,6 +15,7 @@ MODELS_WITH_SEP_TESTS = [
     "tts_models/en/multi-dataset/tortoise-v2",
     "tts_models/multilingual/multi-dataset/xtts_v1.1",
     "tts_models/multilingual/multi-dataset/xtts_v2",
+    "tts_models/multilingual/multi-dataset/omnivoice",
 ]
 
 # These contain np.core.multiarray.scalar which cannot be added safe globals for


### PR DESCRIPTION
## Summary

- register the official `k2-fsa/OmniVoice` Hugging Face checkpoint in the model catalog
- add a thin `BaseTTS` adapter supporting automatic voices, voice cloning/caching, and voice design
- expose the full language set reported by OmniVoice dynamically (currently 646 language IDs)
- keep the dependency optional through `coqui-tts[omnivoice]`
- document installation, inference modes, and the noncommercial model-weight license
- add focused adapter/config tests and classify the 3.3 GB checkpoint as a separately tested large model

## Design notes

The integration delegates text normalization, tokenization, and generation to the upstream `omnivoice` package instead of duplicating its internals. The adapter retains the audio tokenizer on CPU when `.to(cuda)` or `.to(mps)` is used. This reduces accelerator memory use and avoids an unsupported MPS output-channel operation in the tokenizer.

The Hugging Face checkpoint uses a Transformers-style `model_type` config and directory-based SafeTensors layout, so the generic config loader and model manager recognize those forms.

## Validation

- `ruff check` and `ruff format --check` pass for all touched Python files
- focused unit tests pass with the optional dependency mocked
- end-to-end tested with the official checkpoint on an Apple M1 Pro using MPS
- automatic voice: valid mono 24 kHz waveform; ASR transcription was coherent
- voice design (`male, british accent`): exact ASR transcription of the test sentence
- voice cloning from generated reference audio: exact ASR transcription of the test sentence
- verified the runtime exposes all 646 language IDs from `supported_language_ids()`

The large-model test remains skipped on GitHub Actions, consistent with the existing XTTS/Tortoise handling.

## Licensing

The upstream OmniVoice code is Apache-2.0. The official pretrained weights are labeled CC-BY-NC, which is called out in the catalog and inference documentation.